### PR TITLE
remove French translation of readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -13,11 +13,9 @@
   <a href="https://github.com/z-shell/community/issues/new?assignees=&labels=%F0%9F%91%A5+member&template=membership.yml&title=team%3A+">《💜》Join </a>
   <a href="https://digitalclouds.crowdin.com/z-shell/">《🌐》Localize </a>
 </h2>
-<h3>
-<kbd><a href="https://github.com/z-shell/wiki/blob/main/.github/README.fr.md"><img title="Française" alt="Française" src="https://cdn.staticaly.com/gh/hjnilsson/country-flags/master/svg/fr.svg" width="22"></a></kbd>
-<kbd><a href="https://github.com/z-shell/wiki/blob/main/.github/README.md"><img title="English (UK)" alt="English" src="https://cdn.staticaly.com/gh/hjnilsson/country-flags/master/svg/gb.svg" width="22"></a></kbd>
-</h3>
-  </td></tr>
+
+
+  </tr>
 <tr>
 <td align="center">
   <a title="Crowdin" target="_self" href="https://crowdin.digitalclouds.dev/z-shell">


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/z-shell/wiki/0xMRTT-patch-1?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=z-shell&repo=wiki&branch=0xMRTT-patch-1">VS Code</a>

<!-- open-in-codesandbox:complete -->


Because it's useless, difficult to maintain. 

Signed-off-by: 0xMRTT <0xMRTT@tuta.io>