### PR TITLE
Remove enclosing `”` from `${(s.:.)LS_COLORS}` in LS_COLORS snippet

### DIFF
--- a/docs/guides/syntax/01_standard.md
+++ b/docs/guides/syntax/01_standard.md
@@ -205,7 +205,7 @@ A repository [trapd00r/LS_COLORS][trapd00r-ls_colors] provides a file with color
 ```shell showLineNumbers
 zi ice atclone'dircolors -b LS_COLORS > clrs.zsh' \
   atpull'%atclone' pick"clrs.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/ecosystem/annexes/19_eval.md
+++ b/ecosystem/annexes/19_eval.md
@@ -45,7 +45,7 @@ zi light ajeetdsouza/zoxide
 ```shell showLineNumbers
 zi ice atclone"dircolors -b LS_COLORS > init.zsh" \
   atpull"%atclone" pick"init.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 
@@ -60,7 +60,7 @@ zi light ajeetdsouza/zoxide
 
 ```shell {1} showLineNumbers
 zi ice eval"dircolors -b LS_COLORS" \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
+++ b/i18n/ja/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
@@ -45,7 +45,7 @@ zi light ajeetdsouza/zoxide
 ```shell showLineNumbers
 zi ice atclone"dircolors -b LS_COLORS > init.zsh" \
   atpull"%atclone" pick"init.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 
@@ -60,7 +60,7 @@ zi light ajeetdsouza/zoxide
 
 ```shell {1} showLineNumbers
 zi ice eval"dircolors -b LS_COLORS" \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
@@ -205,7 +205,7 @@ A repository [trapd00r/LS_COLORS][trapd00r-ls_colors] provides a file with color
 ```shell showLineNumbers
 zi ice atclone'dircolors -b LS_COLORS > clrs.zsh' \
   atpull'%atclone' pick"clrs.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/ko/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
+++ b/i18n/ko/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
@@ -45,7 +45,7 @@ zi light ajeetdsouza/zoxide
 ```shell showLineNumbers
 zi ice atclone"dircolors -b LS_COLORS > init.zsh" \
   atpull"%atclone" pick"init.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 
@@ -60,7 +60,7 @@ zi light ajeetdsouza/zoxide
 
 ```shell {1} showLineNumbers
 zi ice eval"dircolors -b LS_COLORS" \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
@@ -205,7 +205,7 @@ A repository [trapd00r/LS_COLORS][trapd00r-ls_colors] provides a file with color
 ```shell showLineNumbers
 zi ice atclone'dircolors -b LS_COLORS > clrs.zsh' \
   atpull'%atclone' pick"clrs.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/pl/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
+++ b/i18n/pl/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
@@ -45,7 +45,7 @@ zi light ajeetdsouza/zoxide
 ```shell showLineNumbers
 zi ice atclone"dircolors -b LS_COLORS > init.zsh" \
   atpull"%atclone" pick"init.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 
@@ -60,7 +60,7 @@ zi light ajeetdsouza/zoxide
 
 ```shell {1} showLineNumbers
 zi ice eval"dircolors -b LS_COLORS" \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/pl/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
@@ -205,7 +205,7 @@ A repository [trapd00r/LS_COLORS][trapd00r-ls_colors] provides a file with color
 ```shell showLineNumbers
 zi ice atclone'dircolors -b LS_COLORS > clrs.zsh' \
   atpull'%atclone' pick"clrs.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
+++ b/i18n/ru/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
@@ -45,7 +45,7 @@ zi light ajeetdsouza/zoxide
 ```shell showLineNumbers
 zi ice atclone"dircolors -b LS_COLORS > init.zsh" \
   atpull"%atclone" pick"init.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 
@@ -60,7 +60,7 @@ zi light ajeetdsouza/zoxide
 
 ```shell {1} showLineNumbers
 zi ice eval"dircolors -b LS_COLORS" \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
@@ -205,7 +205,7 @@ A repository [trapd00r/LS_COLORS][trapd00r-ls_colors] provides a file with color
 ```shell showLineNumbers
 zi ice atclone'dircolors -b LS_COLORS > clrs.zsh' \
   atpull'%atclone' pick"clrs.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs-ecosystem/current/annexes/19_eval.md
@@ -45,7 +45,7 @@ zi light ajeetdsouza/zoxide
 ```shell showLineNumbers
 zi ice atclone"dircolors -b LS_COLORS > init.zsh" \
   atpull"%atclone" pick"init.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 
@@ -60,7 +60,7 @@ zi light ajeetdsouza/zoxide
 
 ```shell {1} showLineNumbers
 zi ice eval"dircolors -b LS_COLORS" \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/syntax/01_standard.md
@@ -205,7 +205,7 @@ A repository [trapd00r/LS_COLORS][trapd00r-ls_colors] provides a file with color
 ```shell showLineNumbers
 zi ice atclone'dircolors -b LS_COLORS > clrs.zsh' \
   atpull'%atclone' pick"clrs.zsh" nocompile'!' \
-  atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
+  atload'zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}'
 zi light trapd00r/LS_COLORS
 ```
 


### PR DESCRIPTION
Closes https://github.com/z-shell/wiki/issues/253
