### PR TITLE
Update path to rg completions.

### DIFF
--- a/community/gallery/collection/02_completions.mdx
+++ b/community/gallery/collection/02_completions.mdx
@@ -104,8 +104,8 @@ zi snippet https://github.com/bugaevc/wl-clipboard/blob/master/completions/zsh/_
 ### COMP: [BurntSushi/ripgrep/rg][burntSushi-ripgrep-rg] {#comp-burntsushi-ripgrep-rg}
 
 ```shell showLineNumbers
-zi ice lucid wait as'completion' blockf has'rg'
-zi snippet https://github.com/BurntSushi/ripgrep/blob/master/complete/_rg
+zi ice lucid wait as'completion' blockf has'rg' mv'rg.zsh -> _rg'
+zi snippet https://github.com/BurntSushi/ripgrep/blob/master/crates/core/flags/complete/rg.zsh
 ```
 
 ### COMP: [dbrgn/tealdeer][dbrgn-tealdeer] {#comp-dbrgn-tealdeer}


### PR DESCRIPTION
With the latest release, the path of the rg completions has been changed to crates/core/flags/complete/rg.zsh, see the file history at https://github.com/BurntSushi/ripgrep/commits/master/crates/core/flags/complete/rg.zsh.