### PR TITLE
Add zsh-volta

### DIFF
--- a/community/gallery/collection/06_plugins.mdx
+++ b/community/gallery/collection/06_plugins.mdx
@@ -226,6 +226,14 @@ zi ice wait lucid atload"ztie -d db/redis -a 127.0.0.1:4815/5 -zSL main rdhash"
 zi load z-shell/zredis
 ```
 
+### SC: [cowboyd/zsh-volta](https://github.com/cowboyd/zsh-volta)
+
+```shell showLineNumbers
+# uses feature branch named v1, has no master branch
+zi ice wait lucid ver'v1'
+zi load cowboyd/zsh-volta
+```
+
 ## With [for][4] syntax
 
 ### SC: [z-shell/zsh-eza](https://github.com/z-shell/zsh-eza)


### PR DESCRIPTION
volta is a JS toolchain manager (e.g. node) like nvm with focus being fast, reliable and universal.