### PR TITLE
Update available meta-plugins list in documentation

### DIFF
--- a/ecosystem/annexes/2_meta_plugins.mdx
+++ b/ecosystem/annexes/2_meta_plugins.mdx
@@ -62,7 +62,7 @@ zi light-mode for @annexes \
 | @ext-git         | [git-open][], [git-recent][], [git-my][], [git-quick-stats][], [git-now][], [git-extras][], [forgit][]                |
 | @fuzzy           | [fzf][] (package), [fzy][] (package), [skim][], [peco][]                                                              |
 | @fuzzy-src       | fzf-go, [fzy][], skim-cargo, peco-go                                                                                  |
-| @prezto          | PZTM::archive, PZTM::directory, PZTM::utility                                                                         |
+| @ohmyzsh-lib     | OMZL::git, OMZL::history, OMZL::vcs_info, OMZL::clipboard, OMZL::completion, OMZL::theme-and-appearance, OMZL::prompt_info_functions, OMZL::termsupport, OMZL::key-bindings, OMZL::compfix, OMZL::directories, OMZL::functions |
 | @py-utils        | [pyenv][] (package)                                                                                                   |
 | @romkatv         | [powerlevel10k][]                                                                                                     |
 | @rust-utils      | rust-toolchain, cargo-extensions                                                                                      |


### PR DESCRIPTION
This pull request updates the plugin categorization in the `ecosystem/annexes/2_meta_plugins.mdx` file. The main change is the replacement of the `@prezto` category with a new `@ohmyzsh-lib` category, listing several Oh My Zsh library modules.

Plugin categorization update:

* Replaced the `@prezto` category and its modules with a new `@ohmyzsh-lib` category, listing key Oh My Zsh library modules such as `OMZL::git`, `OMZL::history`, `OMZL::vcs_info`, and others.