### PR TITLE
fix(docs): repair zunit community links

### DIFF
--- a/community/04_zunit/01_installation.mdx
+++ b/community/04_zunit/01_installation.mdx
@@ -83,8 +83,8 @@ To also generate a GitHub Actions workflow:
 zunit init --github-actions
 ```
 
-See [Configuration](./05_configuration) for the `.zunit.yml` key reference and
-[CI Integration](./06_ci) for the generated workflow details.
+See [Configuration](./zunit-configuration) for the `.zunit.yml` key reference and
+[CI Integration](./zunit-ci) for the generated workflow details.
 
 :::note Legacy package-manager recipes
 

--- a/community/04_zunit/04_running-tests.mdx
+++ b/community/04_zunit/04_running-tests.mdx
@@ -93,7 +93,7 @@ directory configured under `directories.output` in `.zunit.yml` (default:
 :::tip
 
 Combine `--tap` with a TAP reporter (e.g., `tap-junit`) in CI to get structured
-test result artifacts. See [CI Integration](./06_ci) for ready-to-use workflow
+test result artifacts. See [CI Integration](./zunit-ci) for ready-to-use workflow
 examples.
 
 :::

--- a/community/04_zunit/index.mdx
+++ b/community/04_zunit/index.mdx
@@ -24,12 +24,12 @@ reports, and a `zunit init` scaffolding command for fast project setup.
 
 | Section | What it covers |
 |---|---|
-| [Installation](./01_installation) | Manual install, dependencies, Zi integration |
-| [Test Syntax](./02_test-syntax) | `@test`, `@setup`/`@teardown`, helper functions |
-| [Assertions](./03_assertions) | All ~25 assertion functions with examples |
-| [Running Tests](./04_running-tests) | CLI usage, flags, output modes |
-| [Configuration](./05_configuration) | `.zunit.yml` key reference |
-| [CI Integration](./06_ci) | GitHub Actions and Travis CI workflows |
+| [Installation](./zunit/zunit-installation) | Manual install, dependencies, Zi integration |
+| [Test Syntax](./zunit/zunit-test-syntax) | `@test`, `@setup`/`@teardown`, helper functions |
+| [Assertions](./zunit/zunit-assertions) | All ~25 assertion functions with examples |
+| [Running Tests](./zunit/zunit-running-tests) | CLI usage, flags, output modes |
+| [Configuration](./zunit/zunit-configuration) | `.zunit.yml` key reference |
+| [CI Integration](./zunit/zunit-ci) | GitHub Actions and Travis CI workflows |
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- align ZUnit community links with the generated public routes used by Docusaurus
- keep child-page links on semantic IDs such as `zunit-ci`
- use the full nested route form from the `/community/zunit` index page so links resolve under `/community/zunit/*`

## Verification

- `pnpm build:en`

## Related

- Fixes #726