### PR TITLE
fix(ci): re-pin GitHub Actions to valid commit SHAs

### DIFF
--- a/.github/workflows/ci-perf.yml
+++ b/.github/workflows/ci-perf.yml
@@ -46,17 +46,17 @@ jobs:
       issues: write # for preactjs/compressed-size-action to create comments
     steps:
       - name: "⤵️ Check out code from GitHub"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: "📦 Setup pnpm"
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: "⎔ Setup node"
-        uses: actions/setup-node@1d71962e4969c231c0ad1f2295c3b40115656507 # v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20"
           cache: "pnpm"
-      - uses: preactjs/compressed-size-action@75744b386426020d674c9af68311bd71901bbe5b # v3.0.0
+      - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # 2.9.1
         with:
           install-script: pnpm i --frozen-lockfile
           build-script: "build:en"
@@ -74,13 +74,13 @@ jobs:
       contents: read
     steps:
       - name: "⤵️ Check out code from GitHub"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: "📦 Setup pnpm"
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: "⎔ Setup node"
-        uses: actions/setup-node@1d71962e4969c231c0ad1f2295c3b40115656507 # v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@6bb031afdd8d862073194397c43f77e830d1f12f # v4.0.0
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@6bb031afdd8d862073194397c43f77e830d1f12f # v4.0.0
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -25,11 +25,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: "⤵️ Check out code from GitHub"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: "🚀 Crowdin Download"
-        uses: crowdin/github-action@94397c43f77e830d1f12f6bb031afdd8d8620731 # v2.16.2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
         with:
           upload_sources: false
           upload_translations: false

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -30,11 +30,11 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: "⤵️ Check out code from GitHub"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: "🚀 Crowdin Upload"
-        uses: crowdin/github-action@94397c43f77e830d1f12f6bb031afdd8d8620731 # v2.16.2
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
         with:
           upload_sources: true
           upload_translations: false

--- a/.github/workflows/knowledge-search-index.yml
+++ b/.github/workflows/knowledge-search-index.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node
-        uses: actions/setup-node@1d71962e4969c231c0ad1f2295c3b40115656507 # v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20"
           cache: pnpm

--- a/.github/workflows/pages-deployment.yml
+++ b/.github/workflows/pages-deployment.yml
@@ -25,13 +25,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: "⤵️  Check out code from GitHub"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: "📦 Setup pnpm"
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: "⎔  Setup node"
-        uses: actions/setup-node@1d71962e4969c231c0ad1f2295c3b40115656507 # v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20"
           cache: "pnpm"
@@ -40,7 +40,7 @@ jobs:
         env:
           NODE_ENV: development
       - name: "🚀 Publish"
-        uses: cloudflare/wrangler-action@ebbaa158a14352136e0d9572f136bb031afdd8d8 # v4.0.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CF_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/r2-sync.yml
+++ b/.github/workflows/r2-sync.yml
@@ -28,11 +28,11 @@ jobs:
     environment: R2
     steps:
       - name: "⤵️ Check out code from GitHub"
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 2
       - name: "⎔ Setup Node.js"
-        uses: actions/setup-node@1d71962e4969c231c0ad1f2295c3b40115656507 # v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20"
       - name: "📦 Install wrangler"

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
         uses: ./.trunk/setup-ci
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@385694c03612503282470762496a7935f8d5f30e # v1.2.4
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
           cache: false
           # Run full link audit on schedule/dispatch, otherwise run standard incremental checks

--- a/.trunk/setup-ci/action.yml
+++ b/.trunk/setup-ci/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: 📦 Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
     - name: ⎔ Setup node
-      uses: actions/setup-node@1d71962e4969c231c0ad1f2295c3b40115656507 # v6.0.0
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version: "20"
         cache: "pnpm"


### PR DESCRIPTION
## Summary

Nearly every action pin in `.github/workflows/` referenced an invalid (fabricated or stale) commit SHA, so **Trunk Check** and **CodeQL** failed at job setup (`unable to find version …`) on every PR and push. Two version comments were also fictional (`codeql-action@v4.0.0` predates the real tag we now use; `compressed-size-action@v3.0.0` never existed).

Each pin was re-resolved against the action's official release tag via the GitHub API and corrected:

| Action | Version | Note |
|---|---|---|
| actions/checkout | v6.0.0 | SHA fixed |
| actions/setup-node | v6.0.0 | SHA fixed |
| crowdin/github-action | v2.16.2 | SHA fixed |
| trunk-io/trunk-action | v1.2.4 | SHA fixed |
| cloudflare/wrangler-action | v4.0.0 | SHA fixed |
| github/codeql-action | v4.0.0 → v4.35.5 | SHA + version |
| preactjs/compressed-size-action | v3.0.0 → 2.9.1 | tag did not exist |
| pnpm/action-setup | v6.0.8 | already correct, unchanged |

Closes #738.

Atomic CI-hygiene change, kept separate from content PRs per workspace conventions. Once merged to `next`, dependent PRs (#736) update from `next` to go green.