### PR TITLE
fix(wiki): broken intro metrics images + missing homepage star count

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -66,13 +66,13 @@ Zi is a Swiss Army Knife for Zsh — a blazing-fast plugin manager with Turbo mo
     alt="Z-Shell Metrics"
     width="100%"
     height="auto"
-    img="https://raw.githubusercontent.com/z-shell/.github/main/metrics/plugin/metrics.svg"
+    img="https://raw.githubusercontent.com/z-shell/.github/metrics/metrics/plugin/metrics.svg"
   />
   <ImgShow
     alt="Z-Shell Repositories"
     width="100%"
     height="auto"
-    img="https://raw.githubusercontent.com/z-shell/.github/main/metrics/plugin/repositories_metrics.svg"
+    img="https://raw.githubusercontent.com/z-shell/.github/metrics/metrics/plugin/repositories_metrics.svg"
   />
 </Link>
 

--- a/src/components/HomeBanner/index.tsx
+++ b/src/components/HomeBanner/index.tsx
@@ -44,7 +44,7 @@ export default function HeroBanner(): React.JSX.Element {
             <iframe
               className={styles.indexCtasGitHubButton}
               src="https://ghbtns.com/github-btn.html?user=z-shell&amp;repo=zi&amp;type=star&amp;count=true&amp;size=large"
-              width={130}
+              width={170}
               height={30}
               title="GitHub Stars"
               loading="lazy"


### PR DESCRIPTION
## Summary
Two unrelated UI bugs reported on the live wiki.

**1. Broken images on the Introduction page (`docs/index.mdx`)**
The "Summary" metrics SVGs referenced `z-shell/.github@main`, but the `metrics.yml` workflow publishes them to the dedicated **`metrics` branch** (`committer_branch: metrics`). The `main` URLs 404. Repointed to the `metrics` branch.
- `…/.github/main/metrics/plugin/metrics.svg` → 404
- `…/.github/metrics/metrics/plugin/metrics.svg` → 200 ✓

**2. Missing star count on the homepage GitHub button (`HomeBanner`)**
Not a CSP issue. The star iframe (`type=star&count=true&size=large`) was `width={130}`, which clips the count bubble. Widened to `170` (matches the adjacent follow button).

## Test plan
- [ ] Cloudflare Pages preview: Introduction page Summary images render (no broken icons)
- [ ] Preview homepage: GitHub star button shows the count
- [ ] Trunk / CodeQL green