### PR TITLE
build(deps): allow ESLint 10 for jsx-a11y peer (silence install warning)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,9 @@ overrides:
   webpackbar: "^7.0.0"
   serialize-javascript: "7.0.5"
   uuid: "14.0.0"
+
+# Allow ESLint 10 (current stable) for plugins whose declared peer range
+# predates it but which work fine with it. Removes install-time peer warnings.
+peerDependencyRules:
+  allowedVersions:
+    "eslint-plugin-jsx-a11y>eslint": "^10"


### PR DESCRIPTION
## Summary
ZSH-11 follow-up. ESLint 10 is the current **stable** major (verified via Context7) and lint passes on it. The only install-time peer warning comes from `eslint-plugin-jsx-a11y@6.10.2`, whose declared peer caps at `^9`. Adds a scoped `pnpm` peer rule allowing eslint 10, silencing the warning **without** downgrading off current stable.

- `@docusaurus/eslint-plugin` already declares `eslint: >=6` — no rule needed (the earlier "^6-8" reading was imprecise).
- Lockfile unchanged (peer rules don't affect resolution).

## Test plan
- [ ] `pnpm install` no longer warns about jsx-a11y/eslint peer
- [ ] Trunk Check green (lint still works on eslint 10)