### PR TITLE
ci(trunk): fix duplicate Trunk Check context blocking PRs

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -1,5 +1,5 @@
 ---
-name: Trunk Check
+name: Trunk Code Quality
 on:
   push:
     branches: [main, next]
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   trunk_check:
-    name: Trunk Check
+    name: Trunk Code Quality
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem (#757)

`trunk-check.yml` named both the **workflow** and the **job** `Trunk Check`. That collides with the check-run `trunk-io/trunk-action` posts (also named `Trunk Check`), producing two identically-named `github-actions` check-runs on every PR. Under strict branch protection with required context `Trunk Check`, GitHub can't disambiguate and leaves PRs `BLOCKED` even when all checks pass (observed on automated zsh-lint docs-sync PRs #756, #758 — both needed admin override).

## Fix

Rename the workflow and job to **`Trunk Code Quality`** (the org-conventional name per CLAUDE.md, and what `z-shell/zsh-lint` already uses). The action's posted `Trunk Check` check-run then remains the single match for the required context — no more collision, no admin override needed.

No change to branch protection required.

## Verify
- [ ] This PR's own checks pass and it is mergeable WITHOUT admin override (proving the collision is gone)