### PR TITLE
docs(zsh-lint): sync generated reference

### DIFF
--- a/ecosystem/plugins/zsh_lint.mdx
+++ b/ecosystem/plugins/zsh_lint.mdx
@@ -46,7 +46,7 @@ Each file gets an `OK`/`FAIL` line; failures include a greppable
 
 	import "github.com/z-shell/zsh-lint/cmd/zsh-lint"
 
-Command zsh\-lint surveys Zsh files with the mvdan/sh parser front end and reports parse success or failure per file \(reboot parser\-evaluation phase, issues \#5, \#8\). Lint rule diagnostics \(issue \#18\) build on this foundation.
+Command zsh\-lint performs static analysis of Zsh shell scripts.
 
 ## Index
 


### PR DESCRIPTION
Automated reference sync from `z-shell/zsh-lint`.
Generated from Go doc comments — do not hand-edit the marked region.
Source commit: 116e81eb02fa134f5e59bb416a0c8b9414f1cf7d