### PR TITLE
docs(packages): drop removed Zsh 5.1.1/5.2.4 from version list

### DIFF
--- a/ecosystem/packages/02_usage.mdx
+++ b/ecosystem/packages/02_usage.mdx
@@ -893,8 +893,6 @@ zi pack"5.6.2" for zsh
 zi pack"5.5.1" for zsh
 zi pack"5.4.2" for zsh
 zi pack"5.3.1" for zsh
-zi pack"5.2.4" for zsh
-zi pack"5.1.1" for zsh
 ```
 
 </TabItem>


### PR DESCRIPTION
Keeps the package usage docs in sync with the manifest.

`ecosystem/packages/02_usage.mdx` listed `zi pack"5.2.4"` and `zi pack"5.1.1"` as selectable Zsh versions. **z-shell/zsh#14** removes those two profiles from the package manifest, so these examples would advertise versions that no longer exist.

This drops the two stale lines to match. Mirrors the same trim made to the repo-local `docs/README.md` in z-shell/zsh#14.

**Merge ordering:** land **after** z-shell/zsh#14 so the docs don't drop the versions before the manifest change is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)