### PR TITLE
docs(zsh-lint): move tool documentation into community

### DIFF
--- a/.github/instructions/agent-docusaurus-writer.instructions.md
+++ b/.github/instructions/agent-docusaurus-writer.instructions.md
@@ -39,7 +39,7 @@ Invoke the `docusaurus-writer` agent and provide:
 Before creating a page, select the root:
 
 - Zi plugin-manager user docs → `docs/`.
-- Community content (contributing, handbook, ZUnit) → `community/`.
+- Community content (contributing, handbook, tools such as ZUnit and Zsh Lint) → `community/`.
 - Third-party ecosystem (annexes, packages, plugins) → `ecosystem/`.
 - Admin / tooling / operational / infrastructure → **not the wiki**; these are
   runbooks for `z-shell/.github/runbooks/`.

--- a/.github/instructions/docs-authoring.instructions.md
+++ b/.github/instructions/docs-authoring.instructions.md
@@ -9,12 +9,12 @@ applyTo: "{docs,community,ecosystem}/**/*.mdx"
 
 Choose the content root before writing. The roots are not interchangeable:
 
-| Content type                                       | Root                                           |
-| -------------------------------------------------- | ---------------------------------------------- |
-| Zi plugin-manager install / commands / usage       | `docs/`                                        |
-| Contributing, Zsh handbook, plugin standard, ZUnit | `community/`                                   |
-| Maintainer / operational / infrastructure runbooks | **not the wiki** — `z-shell/.github/runbooks/` |
-| Third-party annexes, packages, plugins             | `ecosystem/`                                   |
+| Content type                                                                            | Root                                           |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Zi plugin-manager install / commands / usage                                            | `docs/`                                        |
+| Contributing, Zsh handbook, plugin standard, community tools such as ZUnit and Zsh Lint | `community/`                                   |
+| Maintainer / operational / infrastructure runbooks                                      | **not the wiki** — `z-shell/.github/runbooks/` |
+| Third-party annexes, packages, plugins                                                  | `ecosystem/`                                   |
 
 **Prohibition:** Never place maintainer, operational, or infrastructure
 documentation anywhere in the wiki (neither `docs/` nor `community/`). It leaks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ This project follows the organization-wide [Z-Shell Organization Guidelines](htt
   - `docs/` → `/docs` — **Zi plugin manager user documentation only**
     (installation, commands, usage guides).
   - `community/` → `/community` — Z-Shell ecosystem community content:
-    contributing, the Zsh handbook/plugin standard, and ZUnit.
+    contributing, the Zsh handbook/plugin standard, and community tools such as
+    ZUnit and Zsh Lint.
   - `ecosystem/` → `/ecosystem` — third-party catalog: annexes, packages, plugins.
 - **Maintainer, operational, and infrastructure runbooks do not belong on the
   public wiki.** They live in `z-shell/.github/runbooks/`.

--- a/community/00_contributing/04_contributing_docs.mdx
+++ b/community/00_contributing/04_contributing_docs.mdx
@@ -59,7 +59,7 @@ The wiki has three independent docs roots:
 | Directory | URL Prefix | Purpose |
 | --- | --- | --- |
 | `docs/` | `/docs` | Core documentation, getting started, guides |
-| `community/` | `/community` | Community guides, Zsh plugin standard |
+| `community/` | `/community` | Community guides, Zsh plugin standard, tools |
 | `ecosystem/` | `/ecosystem` | Annexes, packages, plugins |
 
 ## File Naming Conventions

--- a/community/04_zsh_lint/_category_.json
+++ b/community/04_zsh_lint/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "🔍 Zsh Lint",
+  "position": 4,
+  "link": {
+    "type": "doc",
+    "id": "zsh_lint"
+  }
+}

--- a/community/04_zsh_lint/index.mdx
+++ b/community/04_zsh_lint/index.mdx
@@ -50,7 +50,7 @@ zsh-lint-survey path/to/file.zsh another.zsh
 
 #### zsh\-lint
 
-	import "github.com/z-shell/zsh-lint/cmd/zsh-lint"
+    import "github.com/z-shell/zsh-lint/cmd/zsh-lint"
 
 Command zsh\-lint performs static analysis of Zsh shell scripts.
 
@@ -60,7 +60,7 @@ Command zsh\-lint performs static analysis of Zsh shell scripts.
 
 #### zsh\-lint\-survey
 
-	import "github.com/z-shell/zsh-lint/cmd/zsh-lint-survey"
+    import "github.com/z-shell/zsh-lint/cmd/zsh-lint-survey"
 
 Command zsh\-lint\-survey runs the parser front end across Zsh files and reports parser gaps without evaluating static\-analysis rules.
 
@@ -70,7 +70,7 @@ Command zsh\-lint\-survey runs the parser front end across Zsh files and reports
 
 #### survey
 
-	import "github.com/z-shell/zsh-lint/internal/survey"
+    import "github.com/z-shell/zsh-lint/internal/survey"
 
 Package survey runs the parser front end across a set of Zsh files and reports, per file, whether parsing succeeded. It produces greppable \`path:line:col: message\` diagnostics for failures and a one\-line summary.
 
@@ -84,7 +84,7 @@ This is the reboot's parser\-evaluation surface \(issues \#5, \#8\): it reports 
 
 ##### func Run
 
-	func Run(names []string, w io.Writer) int
+    func Run(names []string, w io.Writer) int
 
 Run parses each file in names, writing per\-file status and a summary to w.
 

--- a/community/04_zsh_lint/index.mdx
+++ b/community/04_zsh_lint/index.mdx
@@ -1,7 +1,7 @@
 ---
 id: zsh_lint
 title: 🔍 Zsh Lint
-sidebar_position: 13
+sidebar_position: 1
 description: A Go-based semantic analyzer for Zsh.
 keywords:
   - zsh-lint
@@ -14,10 +14,9 @@ keywords:
 
 ## A Go-based semantic analyzer for Zsh
 
-`zsh-lint` is being rebooted as a Go semantic analyzer for Zsh. It parses Zsh
-sources with a real grammar front end and reports problems. It currently
-operates as a **parser survey** — reporting which files the parser accepts — and
-does not implement lint rules yet.
+`zsh-lint` is a standalone Go semantic analyzer for Zsh. It parses Zsh sources
+with a real grammar front end and reports greppable diagnostics from its default
+static-analysis rules.
 
 ### <i class="fa-brands fa-github"></i> [z-shell/zsh-lint][]
 
@@ -33,8 +32,15 @@ go install github.com/z-shell/zsh-lint/cmd/zsh-lint@latest
 zsh-lint path/to/file.zsh another.zsh
 ```
 
-Each file gets an `OK`/`FAIL` line; failures include a greppable
-`path:line:col: message`. The exit code is `0` only if every file parsed.
+Diagnostics use the `path:line:col: [rule-id] message` format. Parse errors,
+warnings, and errors produce a non-zero exit code.
+
+For parser-gap corpus evaluation without static-analysis rules, use the
+dedicated survey command:
+
+```sh
+zsh-lint-survey path/to/file.zsh another.zsh
+```
 
 ### Reference
 
@@ -42,17 +48,27 @@ Each file gets an `OK`/`FAIL` line; failures include a greppable
 
 
 
-# zsh\-lint
+#### zsh\-lint
 
 	import "github.com/z-shell/zsh-lint/cmd/zsh-lint"
 
-Command zsh\-lint surveys Zsh files with the mvdan/sh parser front end and reports parse success or failure per file \(reboot parser\-evaluation phase, issues \#5, \#8\). Lint rule diagnostics \(issue \#18\) build on this foundation.
+Command zsh\-lint performs static analysis of Zsh shell scripts.
 
-## Index
+##### Index
 
 
 
-# survey
+#### zsh\-lint\-survey
+
+	import "github.com/z-shell/zsh-lint/cmd/zsh-lint-survey"
+
+Command zsh\-lint\-survey runs the parser front end across Zsh files and reports parser gaps without evaluating static\-analysis rules.
+
+##### Index
+
+
+
+#### survey
 
 	import "github.com/z-shell/zsh-lint/internal/survey"
 
@@ -60,13 +76,13 @@ Package survey runs the parser front end across a set of Zsh files and reports, 
 
 This is the reboot's parser\-evaluation surface \(issues \#5, \#8\): it reports parser outcomes only and intentionally implements no lint rules yet.
 
-## Index
+##### Index
 
-- [func Run\(names \[\]string, w io.Writer\) int](#Run)
+- [func Run\(names \[\]string, w io.Writer\) int](#func-run)
 
 
 
-## func Run
+##### func Run
 
 	func Run(names []string, w io.Writer) int
 

--- a/community/index.mdx
+++ b/community/index.mdx
@@ -18,7 +18,7 @@ keywords:
 import Link from "@docusaurus/Link";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-The Z-Shell community is home to contributors, plugin authors, and Zsh enthusiasts. Find guides, a plugin gallery, the ZUnit testing framework, and everything you need to get involved.
+The Z-Shell community is home to contributors, plugin authors, and Zsh enthusiasts. Find guides, a plugin gallery, community tools, and everything you need to get involved.
 
 <div style={{textAlign: "center", margin: "1.5rem 0"}}>
   <img
@@ -48,6 +48,13 @@ Join the [Z-Shell organization](https://github.com/z-shell), help [translate the
   <strong>ZUnit</strong>
   <span style={{fontSize: "0.875rem", color: "var(--ifm-color-emphasis-700)"}}>A unit testing framework for Zsh — write @test blocks, run assertions, and integrate with CI.</span>
   <Link to="/community/zunit" style={{marginTop: "auto"}}>Explore ZUnit →</Link>
+</div>
+
+<div style={{border: "1px solid var(--ifm-color-emphasis-300)", borderRadius: "10px", padding: "1rem", display: "flex", flexDirection: "column", gap: "0.5rem"}}>
+  <img src={useBaseUrl("/img/svg/cards/syntax-highlighting.svg")} alt="" width="56" height="56" style={{borderRadius: "8px"}}/>
+  <strong>Zsh Lint</strong>
+  <span style={{fontSize: "0.875rem", color: "var(--ifm-color-emphasis-700)"}}>A standalone semantic analyzer for Zsh scripts with greppable static-analysis diagnostics.</span>
+  <Link to="/community/zsh_lint" style={{marginTop: "auto"}}>Explore Zsh Lint →</Link>
 </div>
 
 <div style={{border: "1px solid var(--ifm-color-emphasis-300)", borderRadius: "10px", padding: "1rem", display: "flex", flexDirection: "column", gap: "0.5rem"}}>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,2 @@
+/ecosystem/plugins/zsh_lint /community/zsh_lint 301
+/ecosystem/plugins/zsh_lint/ /community/zsh_lint 301

--- a/static/_routes.json
+++ b/static/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/*"],
+  "exclude": ["/ecosystem/plugins/zsh_lint", "/ecosystem/plugins/zsh_lint/"]
+}


### PR DESCRIPTION
## Summary
- move the first-party Zsh Lint tool page from the third-party ecosystem catalog into the community tools section
- preserve the former URL with redirects and Cloudflare route exclusions
- update content-placement guidance and seed the generated reference from the analyzer and dedicated survey command

## Validation
- `corepack pnpm validate:frontmatter`
- `corepack pnpm wrangler:typecheck`
- `corepack pnpm build:en`
- `git diff --check origin/next...HEAD`

Supersedes #760.