### PR TITLE
ci(trunk): use organization reusable workflow

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
       checks: write
       contents: read
-    uses: z-shell/.github/.github/workflows/trunk.yml@adfd5fd7cb037a141f77806fb501250d217c56c7 # main
+    uses: z-shell/.github/.github/workflows/trunk.yml@df7c51baaa966337fe5e8d15d82bc9c38486a227 # main
     with:
       cache: false
       setup-deps: true

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -10,33 +10,22 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  checks: write
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  trunk_check:
+  check:
     name: Trunk Code Quality
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Setup dependencies
-        uses: ./.trunk/setup-ci
-
-      - name: Trunk Check
-        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
-        with:
-          cache: false
-          # Run full link audit on schedule/dispatch, otherwise run standard incremental checks
-          arguments: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'run lychee-audit' || '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+    uses: z-shell/.github/.github/workflows/trunk.yml@544f83bb39d379900eae8cf88c02de04a53efcc0 # main
+    with:
+      cache: false
+      setup-deps: true
+      # Run full link audit on schedule/dispatch, otherwise run standard incremental checks.
+      arguments: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'run lychee-audit' || '' }}

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
       checks: write
       contents: read
-    uses: z-shell/.github/.github/workflows/trunk.yml@544f83bb39d379900eae8cf88c02de04a53efcc0 # main
+    uses: z-shell/.github/.github/workflows/trunk.yml@adfd5fd7cb037a141f77806fb501250d217c56c7 # main
     with:
       cache: false
       setup-deps: true


### PR DESCRIPTION
## Summary
- replace the wiki's embedded Trunk action workflow with the organization reusable workflow
- reduce top-level permissions to `contents: read`
- preserve dependency setup and the scheduled/manual `lychee-audit` mode

## Verification
- YAML parse with Ruby Psych
- `git diff --check`
- workspace audit of active Trunk callers
- pre-push Trunk check: passed

Tracks z-shell/.github#408.