### PR TITLE
chore(deps): activate organization Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>z-shell/.github:renovate-config", ":dependencyDashboardApproval", ":disableVulnerabilityAlerts"]
+}


### PR DESCRIPTION
## Summary

- activate the shared `local>z-shell/.github:renovate-config` preset from the default branch
- require Dependency Dashboard approval during Stage 1 so Renovate cannot open routine update PRs yet
- disable Renovate vulnerability-alert remediation so Dependabot retains security ownership
- supersede the ungated, unformatted onboarding PR #779
- keep `.github/dependabot.yml` unchanged until live Renovate processing and GitHub security settings are verified

## Safety boundary

This is Stage 1 of https://github.com/z-shell/.github/issues/452. Do not approve any Dependency Dashboard update while this gate is active. Stage 2 will remove routine Dependabot configuration and the dashboard-approval gate atomically only after the tracker’s live-processing, security-settings, and zero-open-routine-Dependabot-PR gates pass.

## Verification

- exact JSON structure: pass
- `jq empty renovate.json`: pass
- `git diff --check`: pass
- signed focused commit: pass
- Renovate validator: identical non-Zi configuration passed the official validator in the rollout validation set

Draft until direct validator coverage and repository checks are green.

Tracks: https://github.com/z-shell/.github/issues/452