### PR TITLE
docs(contributing): point the label source of truth at lib/labels.yml

### DIFF
--- a/community/00_contributing/05_project_management.mdx
+++ b/community/00_contributing/05_project_management.mdx
@@ -106,7 +106,7 @@ Labels are applied manually during triage or by approved organization
 automation.
 
 The source of truth lives in
-[`z-shell/.github/.github/lib/labels.yml`](https://github.com/z-shell/.github/blob/main/.github/lib/labels.yml).
+[`z-shell/.github/lib/labels.yml`](https://github.com/z-shell/.github/blob/main/lib/labels.yml).
 Rollout across repositories is handled through organization maintenance automation.
 
 ### Work Type Labels


### PR DESCRIPTION
Supports [z-shell/.github#461](https://github.com/z-shell/.github/issues/461).

## What

`community/00_contributing/05_project_management.mdx` linked the canonical label set to `z-shell/.github/.github/lib/labels.yml`. That file is a stale duplicate being removed in [z-shell/.github#471](https://github.com/z-shell/.github/pull/471).

The real source of truth — and the file `scripts/labels-sync.rb` actually reads — is `lib/labels.yml` at that repository's root. It carries 32 labels plus the `legacy_migrations` and `sync_policy` blocks; the copy being removed was a bare YAML array of 29 labels with neither.

## Ordering

Safe to merge in either order. The new target already resolves (`HTTP 200`), so the link is correct before and after the duplicate is deleted. This PR is what stops the wiki from developing a dead link when it is.

This link was found by a consumer audit run before anything was removed — it was the only reference to that file outside `z-shell/.github`.