### PR TITLE
docs(contributing): fix the dead labels.yml link on main

### DIFF
--- a/community/00_contributing/05_project_management.mdx
+++ b/community/00_contributing/05_project_management.mdx
@@ -106,7 +106,7 @@ Labels are applied manually during triage or by approved organization
 automation.
 
 The source of truth lives in
-[`z-shell/.github/.github/lib/labels.yml`](https://github.com/z-shell/.github/blob/main/.github/lib/labels.yml).
+[`z-shell/.github/lib/labels.yml`](https://github.com/z-shell/.github/blob/main/lib/labels.yml).
 Rollout across repositories is handled through organization maintenance automation.
 
 ### Work Type Labels


### PR DESCRIPTION
One-line fix to unblock [#803](https://github.com/z-shell/wiki/pull/803).

## The deadlock

`main` links to `https://github.com/z-shell/.github/blob/main/.github/lib/labels.yml`, which became a **404** when that duplicate file was removed in [z-shell/.github#471](https://github.com/z-shell/.github/pull/471).

The corrected link is already on `next` (#802). But:

- `main` requires the `Trunk Check` context, with **strict** mode (branches must be up to date)
- `Trunk Check` runs lychee against `main`'s content and fails on that 404
- So the promotion PR that would deliver the fix is blocked by the absence of the fix

## The fix

The same one-line correction, applied directly to `main`. Identical to what is already on `next`, so the two converge with no conflict and #803 can then proceed.

The new target resolves (`HTTP 200`); the old one is intentionally gone.