### PR TITLE
ci(branches): guard main promotion sources

### DIFF
--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,30 @@
+---
+name: Main Branch Source Guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard main branch source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify pull request source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
+            echo "Head branch '${HEAD_REF}' is allowed to target main."
+            exit 0
+          fi
+          echo "::error::Pull requests into main must come from 'next' or a 'hotfix-*' branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
+          exit 1

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Verify pull request source branch
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
+          if [[ "${HEAD_REPOSITORY}" != "${REPOSITORY}" ]]; then
+            echo "::error::Pull requests into main must come from this repository (got '${HEAD_REPOSITORY}')."
+            exit 1
+          fi
           if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
             echo "Head branch '${HEAD_REF}' is allowed to target main."
             exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["next"],
   "extends": ["local>z-shell/.github:renovate-config", ":dependencyDashboardApproval", ":disableVulnerabilityAlerts"]
 }


### PR DESCRIPTION
## Summary

- add the organization-standard source guard for pull requests targeting `main`
- allow only `next` and `hotfix-*` source branches
- route Renovate updates to the development branch, `next`

## Why

The wiki uses `next -> main`, but `main` lacked the executable source-branch guard and Renovate still targeted the default branch. This hotfix establishes the guard on the deployed branch without promoting the currently divergent `next` history.

Part of #814.

## Validation

- configuration contract assertions
- `trunk check --upstream origin/main`
- `pnpm wrangler:typecheck`
- `pnpm build:en`
- signed commit verification