### PR TITLE
ci(branches): complete next-first automation routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require the maintainer to approve generated zsh-lint reference updates.
+/docs/zsh-lint/reference.mdx @ss-o
+
+# Protect this targeted review policy.
+/.github/CODEOWNERS @ss-o

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -35,6 +36,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -1,0 +1,30 @@
+---
+name: Main Branch Source Guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard main branch source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify pull request source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
+            echo "Head branch '${HEAD_REF}' is allowed to target main."
+            exit 0
+          fi
+          echo "::error::Pull requests into main must come from 'next' or a 'hotfix-*' branch (got '${HEAD_REF}'). See ADR-0008 (z-shell/.github) for the branching model."
+          exit 1

--- a/.github/workflows/main-branch-guard.yml
+++ b/.github/workflows/main-branch-guard.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Verify pull request source branch
         env:
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
+          if [[ "${HEAD_REPOSITORY}" != "${REPOSITORY}" ]]; then
+            echo "::error::Pull requests into main must come from this repository (got '${HEAD_REPOSITORY}')."
+            exit 1
+          fi
           if [[ "${HEAD_REF}" == "next" || "${HEAD_REF}" == hotfix-* ]]; then
             echo "Head branch '${HEAD_REF}' is allowed to target main."
             exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["next"],
   "extends": ["local>z-shell/.github:renovate-config", ":dependencyDashboardApproval", ":disableVulnerabilityAlerts"]
 }


### PR DESCRIPTION
## Summary

- add the organization-standard source guard for pull requests targeting `main`
- require allowed promotion branches to originate from `z-shell/wiki`, rejecting same-named fork branches
- route Renovate and both Dependabot ecosystems to the development branch, `next`

## Why

The wiki uses `next -> main`, but automation targeting on `next` was stale and the source-branch guard was absent. The live repository protections have already been migrated from duplicate classic rules to repository rulesets, automatic branch deletion is disabled, and the source guard is now required on `main` following #816.

Closes #814.

## Validation

- red-green source and repository identity contract
- `trunk check --upstream origin/next`
- `pnpm wrangler:typecheck`
- `pnpm build:en`
- signed commit verification