### PR TITLE
fix(repo): correct generated reference owner path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Require the maintainer to approve generated zsh-lint reference updates.
-/docs/zsh-lint/reference.mdx @ss-o
+/community/04_zsh_lint/index.mdx @ss-o
 
 # Protect this targeted review policy.
 /.github/CODEOWNERS @ss-o


### PR DESCRIPTION
## Summary

Point the generated Zsh Lint CODEOWNER rule at the page that actually contains the synchronized reference:

- from nonexistent `/docs/zsh-lint/reference.mdx`
- to `/community/04_zsh_lint/index.mdx`

The CODEOWNERS self-protection rule remains unchanged.

## Validation

- confirmed the new target exists and the old target does not
- `pnpm lint`
- `git diff --check`

Resolves the current review thread on promotion #833.
