### PR TITLE
perf(assets): compress asciicast responses

### DIFF
--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -6,11 +6,20 @@ interface Env {
 }
 
 const immutableAssetPrefixes = ["/assets/", "/cdn/", "/img/"];
+const asciicastContentType = "text/plain; charset=utf-8";
 const {contentSignal} = contentPolicy;
 
-function withContentSignal(response: Response): Response {
-  const headers = new Headers(response.headers);
+function applyContentHeaders(headers: Headers, pathname?: string): void {
   headers.set("Content-Signal", contentSignal);
+  // Cloudflare compresses text/plain responses, unlike the default application/octet-stream used for .cast files.
+  if (pathname?.endsWith(".cast")) {
+    headers.set("Content-Type", asciicastContentType);
+  }
+}
+
+function withContentHeaders(response: Response, pathname?: string): Response {
+  const headers = new Headers(response.headers);
+  applyContentHeaders(headers, pathname);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -32,20 +41,20 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     });
   }
 
+  const url = new URL(context.request.url);
   const response = await context.next();
   if (response.status !== 404) {
-    return withContentSignal(response);
+    return withContentHeaders(response, url.pathname);
   }
 
   if (context.request.method !== "GET" && context.request.method !== "HEAD") {
-    return withContentSignal(response);
+    return withContentHeaders(response);
   }
 
-  const url = new URL(context.request.url);
   const key = url.pathname.slice(1);
 
   if (!key) {
-    return withContentSignal(response);
+    return withContentHeaders(response);
   }
 
   // Honor the conditional (If-None-Match) and Range request headers advertised
@@ -56,7 +65,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   });
 
   if (!object) {
-    return withContentSignal(response);
+    return withContentHeaders(response);
   }
 
   const headers = new Headers();
@@ -69,7 +78,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   headers.set("ETag", object.httpEtag);
   headers.set("Access-Control-Allow-Origin", "*");
   headers.set("Accept-Ranges", "bytes");
-  headers.set("Content-Signal", contentSignal);
+  applyContentHeaders(headers, url.pathname);
   if (url.pathname.startsWith("/cdn/")) {
     headers.set("X-Robots-Tag", "noindex, noarchive");
   }


### PR DESCRIPTION
## Summary

- serve `.cast` terminal recordings as `text/plain; charset=utf-8` instead of `application/octet-stream`
- apply the MIME override to both Pages assets and the R2 fallback path
- preserve existing cache, range, CORS, and content-signal headers

## Impact

Cloudflare compresses `text/plain` responses but does not compress the current `application/octet-stream` responses. The homepage recording is 2,472,581 bytes raw and 207,708 bytes with gzip, reducing its transfer by about 91.6% (2.26 MB). Across all 15 recordings, the gzip baseline drops from 3,914,319 bytes to 351,807 bytes (91.0%).

## Validation

- `pnpm exec eslint "functions/[[path]].ts"`
- `pnpm wrangler:typecheck`
- `pnpm build:en`
- local Pages runtime returned `Content-Type: text/plain; charset=utf-8` for `/cdn/cast/509113.cast` while retaining immutable caching and the content-signal header