### PR TITLE
fix(ci): provision Zsh for standard review

### DIFF
--- a/.github/workflows/plugin-standard-review.yml
+++ b/.github/workflows/plugin-standard-review.yml
@@ -32,6 +32,8 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Install Zsh
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends zsh
       - name: Validate deterministic contract
         run: pnpm validate:plugin-standard
       - name: Open ecosystem relevance review

--- a/scripts/validate-plugin-standard.mjs
+++ b/scripts/validate-plugin-standard.mjs
@@ -296,6 +296,11 @@ export function validateWorkflow(content) {
       run: "pnpm install --frozen-lockfile",
     },
     {
+      name: "Install Zsh",
+      keys: ["name", "run"],
+      run: "sudo apt-get update && sudo apt-get install --yes --no-install-recommends zsh",
+    },
+    {
       name: "Validate deterministic contract",
       keys: ["name", "run"],
       run: "pnpm validate:plugin-standard",
@@ -335,7 +340,7 @@ export function validateWorkflow(content) {
     }
   }
 
-  const [, , setupNodeStep, , , issueStep] = steps;
+  const [, , setupNodeStep, , , , issueStep] = steps;
   if (
     !hasExactKeys(setupNodeStep.with, ["node-version", "cache"]) ||
     setupNodeStep.with["node-version"] !== "22" ||

--- a/scripts/validate-plugin-standard.test.mjs
+++ b/scripts/validate-plugin-standard.test.mjs
@@ -54,6 +54,7 @@ test("propagates a nonzero loader status after cleanup", () => {
     .replace("# Register the plugin's persistent functions, hooks, and state.", "return 23");
   const result = spawnSync("zsh", ["-f", "-c", `${example}\nexit $?`], {encoding: "utf8"});
 
+  assert.equal(result.error, undefined);
   assert.equal(result.status, 23, result.stderr);
 });
 
@@ -100,15 +101,36 @@ test("rejects removal of scheduled issue creation", () => {
 
 test("rejects validation before repository setup", () => {
   const parsed = parse(workflow);
-  const [validateStep] = parsed.jobs.review.steps.splice(4, 1);
+  const [validateStep] = parsed.jobs.review.steps.splice(5, 1);
   parsed.jobs.review.steps.unshift(validateStep);
   assert.match(validateWorkflow(JSON.stringify(parsed)).join("\n"), /step 1/);
+});
+
+test("rejects removal of Zsh provisioning", () => {
+  const parsed = parse(workflow);
+  parsed.jobs.review.steps.splice(4, 1);
+  assert.match(validateWorkflow(JSON.stringify(parsed)).join("\n"), /complete required step sequence/);
+});
+
+test("rejects mutation of Zsh provisioning", () => {
+  const invalid = workflow.replace(
+    "sudo apt-get update && sudo apt-get install --yes --no-install-recommends zsh",
+    "sudo apt-get install --yes zsh",
+  );
+  assert.match(validateWorkflow(invalid).join("\n"), /Install Zsh must run/);
+});
+
+test("rejects Zsh provisioning after deterministic validation", () => {
+  const parsed = parse(workflow);
+  const [zshStep] = parsed.jobs.review.steps.splice(4, 1);
+  parsed.jobs.review.steps.splice(5, 0, zshStep);
+  assert.match(validateWorkflow(JSON.stringify(parsed)).join("\n"), /step 5 must be Install Zsh/);
 });
 
 test("rejects extra triggers and skippable required steps", () => {
   const parsed = parse(workflow);
   parsed.on.push = {};
-  parsed.jobs.review.steps[4].if = false;
+  parsed.jobs.review.steps[5].if = false;
   const errors = validateWorkflow(JSON.stringify(parsed)).join("\n");
   assert.match(errors, /exactly schedule and workflow_dispatch/);
   assert.match(errors, /must not be skipped/);
@@ -128,7 +150,7 @@ test("rejects behavior-changing workflow mapping fields", () => {
   parsed.on.schedule[0].timezone = "Europe/London";
   parsed.jobs.review.strategy = {matrix: {node: [22]}};
   parsed.jobs.review.steps[0].with = {repository: "other/repository"};
-  parsed.jobs.review.steps[5].env.NODE_OPTIONS = "--import=./other.mjs";
+  parsed.jobs.review.steps[6].env.NODE_OPTIONS = "--import=./other.mjs";
   const errors = validateWorkflow(JSON.stringify(parsed)).join("\n");
   assert.match(errors, /07:23 UTC/);
   assert.match(errors, /review job must contain only/);


### PR DESCRIPTION
## Summary

- provision Zsh explicitly on the Ubuntu runner before deterministic plugin-standard validation
- require the exact safe provisioning command and ordering in the semantic workflow contract
- reject removal, mutation, and reordering of Zsh provisioning while keeping the native Zsh execution regression active

## Production incident

The first manual dispatch failed because the runner did not provide a `zsh` executable, causing `spawnSync` to return a null status instead of the expected status 23:

https://github.com/z-shell/wiki/actions/runs/31883425312

Closes #843

## Follow-up

After this hotfix lands on `main`, reconcile it into `next` so the production fix is preserved in the integration branch.