### PR TITLE
docs(commands): document Zi version reporting

### DIFF
--- a/docs/guides/01_commands.mdx
+++ b/docs/guides/01_commands.mdx
@@ -241,10 +241,11 @@ Following commands are passed to `zi …` to obtain described effects.
 
 ## Help & manual {/* #help--manual */}
 
-|  Command   | Description        |
-| :--------: | ------------------ |
-| `-h, help` | Usage information. |
-|   `man`    | Manual.            |
+|              Command              | Description                                                                                          |
+| :-------------------------------: | ---------------------------------------------------------------------------------------------------- |
+|            `-h, help`             | Usage information.                                                                                   |
+|               `man`               | Manual.                                                                                              |
+| `version`, `--version`, or `-V`    | Show the exact Git tag, the abbreviated commit for an untagged checkout, or `unknown` without Git metadata. |
 
 ## Commands available using <kbd>^TAB</kbd> [completion](/docs/getting_started/installation#enable-zi-completions) {/* #commands-available-using-tab-completion */}
 


### PR DESCRIPTION
## Summary

- document `zi version`, `zi --version`, and `zi -V`
- explain exact-tag, untagged-checkout, and missing-Git-metadata output

## Validation

- `node scripts/validate-frontmatter.mjs`
- `./node_modules/.bin/docusaurus build --locale en`
- `git diff --check`

Trunk lint was not completed because its pinned tool bootstrap stalled in this environment. The direct repository validators above passed.

Closes #863

Related: z-shell/zi#404 and z-shell/zi#398
