### PR TITLE
docs(meta-plugins): document restored Prezto group

### DIFF
--- a/ecosystem/annexes/2_meta_plugins.mdx
+++ b/ecosystem/annexes/2_meta_plugins.mdx
@@ -63,6 +63,7 @@ zi light-mode for @annexes \
 | @fuzzy           | [fzf][] (package), [fzy][] (package), [skim][], [peco][]                                                              |
 | @fuzzy-src       | fzf-go, [fzy][], skim-cargo, peco-go                                                                                  |
 | @ohmyzsh-lib     | OMZL::git, OMZL::history, OMZL::vcs_info, OMZL::clipboard, OMZL::completion, OMZL::theme-and-appearance, OMZL::prompt_info_functions, OMZL::termsupport, OMZL::key-bindings, OMZL::compfix, OMZL::directories, OMZL::functions |
+| @prezto          | PZTM::archive, PZTM::directory, PZTM::utility                                                                            |
 | @py-utils        | [pyenv][] (package)                                                                                                   |
 | @romkatv         | [powerlevel10k][]                                                                                                     |
 | @rust-utils      | rust-toolchain, cargo-extensions                                                                                      |
@@ -76,6 +77,14 @@ zi light-mode for @annexes \
 ```mdx-code-block
 </APITable>
 ```
+
+:::info[Zi compatibility]
+
+`@prezto` requires a Zi build with Git sparse-checkout support for GitHub directory snippets, introduced by
+[z-shell/zi#417][zi-git-sparse]. The archive module is installed as a directory snapshot; the directory and utility
+modules remain single-file snippets.
+
+:::
 
 ### Summary of the meta-plugins {/* #summary-of-the-meta-plugins */}
 
@@ -193,3 +202,4 @@ This will register the `skip'…'` ice-modifier.
 [zui]: https://github.com/z-shell/zui
 [zunit]: https://github.com/z-shell/zunit
 [z-shell/zsh-fancy-completions]: https://github.com/z-shell/zsh-fancy-completions
+[zi-git-sparse]: https://github.com/z-shell/zi/pull/417


### PR DESCRIPTION
## Summary

- list the restored `@prezto` meta-plugin and its three modules
- explain that `PZTM::archive` uses Zi Git sparse directory-snippet support
- link the Zi implementation that made the restoration possible

The removed `@ohmyzsh-svn-lib` group remains intentionally undocumented and unavailable.

## Dependencies

- [z-shell/zi#420](https://github.com/z-shell/zi/pull/420) promoted the required backend to Zi `main`
- [z-shell/z-a-meta-plugins#49](https://github.com/z-shell/z-a-meta-plugins/pull/49) restored the implementation

## Verification

- `pnpm validate:frontmatter`
- `pnpm build:en`
- 9 LLM corpus tests
- 71 generated artifacts and 65 canonical documents validated
- `git diff --check`