### PR TITLE
docs(zsh-lint): add beginner guides

### DIFF
--- a/community/04_zsh_lint/01_getting_started.mdx
+++ b/community/04_zsh_lint/01_getting_started.mdx
@@ -1,0 +1,78 @@
+---
+id: zsh-lint-getting-started
+title: Getting started
+sidebar_position: 2
+description: Install Zsh Lint v1.1.0 and run a first semantic check.
+keywords:
+  - zsh-lint
+  - installation
+  - quickstart
+  - zsh
+---
+
+## What you need
+
+- Go 1.25 or a compatible version accepted by the module
+- A Zsh source file to inspect
+
+Zsh itself is strongly recommended for a native syntax check, but the linter
+binary is written in Go and does not source or execute the file it analyzes.
+
+## Install a reproducible version
+
+```sh
+go install github.com/z-shell/zsh-lint/cmd/zsh-lint@v1.1.0
+```
+
+Confirm that your shell can find it:
+
+```sh
+zsh-lint 2>&1 | head -n 1
+```
+
+Seeing the usage line confirms the binary runs. It exits with status 2 because
+no input path was supplied. If the command is not found, use:
+
+```sh
+"$(go env GOPATH)/bin/zsh-lint" 2>&1 | head -n 1
+```
+
+## Make a small input
+
+Save this as `hello.zsh`:
+
+```zsh
+#!/usr/bin/env zsh
+
+emulate -R zsh
+print -r -- "${1:-hello}"
+```
+
+Check native Zsh syntax, then run semantic analysis:
+
+```sh
+zsh -f -n -- hello.zsh
+zsh-lint hello.zsh
+```
+
+No output and exit status 0 means the file parsed and no warning or error was
+reported. A finding looks like this:
+
+```text
+hello.zsh:4:13: [quoting/unquoted-var] Variable expansion should be double-quoted
+```
+
+The bracketed value is the rule ID. Use it to find rule details or write a
+narrow suppression.
+
+## Check more than one file
+
+```sh
+zsh-lint bin/build.zsh functions/example-run example.plugin.zsh
+```
+
+Each argument must be a readable file. Zsh Lint does not recurse through a
+directory or read source from standard input in v1.1.0.
+
+Next, read [Choosing files](./02_choosing_files.mdx) before applying the command
+to a mixed-language repository.

--- a/community/04_zsh_lint/02_choosing_files.mdx
+++ b/community/04_zsh_lint/02_choosing_files.mdx
@@ -1,0 +1,63 @@
+---
+id: zsh-lint-choosing-files
+title: Choosing files
+sidebar_position: 3
+description: Understand how Zsh Lint selects inputs and safely build an explicit file list.
+keywords:
+  - zsh-lint
+  - shebang
+  - file discovery
+  - zsh files
+---
+
+## The rule is simple
+
+In the published v1.1.0 CLI, every positional argument is a file to parse as
+Zsh. The path is the selection signal.
+
+| Input signal                      | Used to recognize Zsh? | What happens                                             |
+| --------------------------------- | ---------------------- | -------------------------------------------------------- |
+| Explicit file path                | Yes                    | The file is opened and parsed as Zsh.                    |
+| `#!/usr/bin/env zsh` shebang      | No                     | It is ordinary source text to the parser.                |
+| `.zsh` or `.plugin.zsh` extension | No                     | Extensions have no special meaning.                      |
+| Extensionless function name       | No automatic detection | It works when passed explicitly.                         |
+| Directory path                    | No                     | Opening the directory fails; there is no recursive scan. |
+| Standard input                    | No                     | The CLI requires one or more paths.                      |
+
+This means both of these are accepted as inputs:
+
+```sh
+zsh-lint script.zsh
+zsh-lint functions/example-run
+```
+
+It also means `zsh-lint deploy.sh` does not decide whether `deploy.sh` is Zsh,
+Bash, or POSIX shell. If you pass it, the parser applies Zsh semantics.
+
+## Prefer a reviewed input list
+
+For a small project, list the files directly in CI. For a larger project,
+build a list from repository conventions and review what it selects:
+
+```sh
+git ls-files -- '*.zsh' '*.plugin.zsh'
+git ls-files -z -- '*.zsh' '*.plugin.zsh' | xargs -0 -r zsh-lint
+```
+
+The extension patterns do not include extensionless autoloaded functions.
+Add known function directories explicitly, for example:
+
+```sh
+find functions completions -type f -print0 | xargs -0 -r zsh-lint
+```
+
+Do not blindly lint every `*.sh` file in a mixed-shell repository. First
+classify whether each file is native Zsh, Bash, or portable `sh`.
+
+## What is planned
+
+Automatic discovery and classification, including possible shebang and
+extension policies, require an explicit design because real Zsh projects also
+contain extensionless functions, startup files, fixtures, and generated code.
+That work is tracked in
+[zsh-lint issue 183](https://github.com/z-shell/zsh-lint/issues/183).

--- a/community/04_zsh_lint/03_project_configuration.mdx
+++ b/community/04_zsh_lint/03_project_configuration.mdx
@@ -1,0 +1,83 @@
+---
+id: zsh-lint-project-configuration
+title: Project configuration preview
+sidebar_position: 4
+description: Try the unreleased project and source-profile configuration available on main.
+keywords:
+  - zsh-lint
+  - configuration
+  - plugin
+  - source profiles
+---
+
+:::warning Unreleased feature
+The published v1.1.0 binary does not recognize `--config`. This page documents
+behavior currently on the `main` branch so early testers can provide feedback.
+Do not add it to release-pinned CI until a release includes the option.
+:::
+
+Project configuration gives rules explicit context that one syntax tree cannot
+provide, such as whether a source is an executable, sourced plugin entrypoint,
+autoloaded function, completion, or test fixture. Version 1 does not discover a
+configuration file automatically, so pass `--config` on every invocation.
+
+## Try the standalone example
+
+Build the current source checkout:
+
+```sh
+git clone https://github.com/z-shell/zsh-lint.git
+cd zsh-lint
+go build -o ./zsh-lint ./cmd/zsh-lint
+./zsh-lint --config examples/standalone/zsh-lint.json \
+  examples/standalone/script.zsh
+```
+
+The source checkout's `examples/standalone` and `examples/plugin` directories
+contain the validated examples used on this page. Their delivery is tracked in
+[zsh-lint issue 182](https://github.com/z-shell/zsh-lint/issues/182).
+
+## Minimal configuration
+
+```json
+{
+  "version": 1,
+  "project": {
+    "kind": "application",
+    "minimum_zsh": "5.8",
+    "function_namespaces": []
+  },
+  "sources": [{"root": "script.zsh", "profile": "standalone-executable"}]
+}
+```
+
+Paths are relative to the directory containing the configuration. Every input
+must stay under that directory and match one source root.
+
+## Source profiles
+
+| Profile                 | Use it for                                                            |
+| ----------------------- | --------------------------------------------------------------------- |
+| `standalone-executable` | A script launched as its own process.                                 |
+| `startup-file`          | Files such as `.zshrc` or `.zprofile`.                                |
+| `sourced-library`       | Plugin entrypoints and libraries loaded into an existing shell.       |
+| `autoload-function`     | One function body loaded through Zsh `autoload`.                      |
+| `test-fixture`          | Test inputs that should not inherit production lifecycle assumptions. |
+
+The optional `completion` role is valid only with `autoload-function`.
+
+## Plugin example
+
+```sh
+./zsh-lint --config examples/plugin/zsh-lint.json \
+  examples/plugin/example.plugin.zsh \
+  examples/plugin/functions/example-run \
+  examples/plugin/completions/_example \
+  examples/plugin/tests/example-fixture.zsh
+```
+
+Configured analysis treats the complete explicit input list as one project.
+Files you omit are outside cross-file validation.
+
+For the strict schema and failure contract, see the
+[source-adjacent project configuration contract](https://github.com/z-shell/zsh-lint/blob/main/docs/project/project-configuration.md).

--- a/community/04_zsh_lint/04_rules_and_suppressions.mdx
+++ b/community/04_zsh_lint/04_rules_and_suppressions.mdx
@@ -1,0 +1,63 @@
+---
+id: zsh-lint-rules-and-suppressions
+title: Rules and suppressions
+sidebar_position: 5
+description: Read Zsh Lint diagnostics and suppress one intentional finding safely.
+keywords:
+  - zsh-lint
+  - rules
+  - suppressions
+  - diagnostics
+---
+
+## Read a diagnostic
+
+Human-readable output uses this shape:
+
+```text
+path:line:column: [rule-id] message
+```
+
+For example:
+
+```text
+lib/render.zsh:8:10: [quoting/unquoted-var] Variable expansion should be double-quoted
+```
+
+The rule ID is stable machine-facing identity. Browse the
+[published rule reference](./08_rule_reference.mdx) for each rule's purpose,
+examples, severity, and suppression form.
+
+Warnings and errors make the command exit 1. Info and Hint findings are still
+reported but do not make the command fail.
+
+## Fix first, suppress only when intentional
+
+A suppression names the exact rule and applies to one source line:
+
+```zsh
+print $words  # zsh-lint disable=quoting/unquoted-var -- intentional word splitting
+```
+
+You can also put it on the preceding comment line. It then applies to the next
+non-comment, non-blank source line:
+
+```zsh
+# zsh-lint disable=quoting/unquoted-var -- intentional word splitting
+print $words
+```
+
+Multiple rule IDs are comma-separated without spaces:
+
+```zsh
+# zsh-lint disable=rule/one,rule/two -- compatibility boundary
+command_to_review
+```
+
+There is no blanket, block-wide, or file-wide disable in the published
+contract. A malformed directive reports `meta/malformed-suppression`. A rule
+ID that suppresses nothing reports `meta/unused-suppression`, which helps keep
+exceptions from becoming stale.
+
+Use a short reason even when it is optional. The reason lets the next reviewer
+decide whether the exception is still valid.

--- a/community/04_zsh_lint/05_ci_and_json.mdx
+++ b/community/04_zsh_lint/05_ci_and_json.mdx
@@ -1,0 +1,80 @@
+---
+id: zsh-lint-ci-and-json
+title: CI and JSON output
+sidebar_position: 6
+description: Run a pinned Zsh Lint release in GitHub Actions and consume JSON diagnostics.
+keywords:
+  - zsh-lint
+  - github actions
+  - ci
+  - json
+---
+
+## A reproducible GitHub Actions job
+
+This example pins the actions and the linter release. Replace the file list
+with the reviewed Zsh inputs in your repository.
+
+```yaml
+name: Zsh checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25"
+      - name: Install Zsh Lint
+        run: go install github.com/z-shell/zsh-lint/cmd/zsh-lint@v1.1.0
+      - name: Check native syntax
+        run: zsh -f -n -- scripts/build.zsh example.plugin.zsh
+      - name: Run semantic analysis
+        run: zsh-lint scripts/build.zsh example.plugin.zsh
+```
+
+The native `zsh -n` check remains useful because official Zsh semantics are
+authoritative when a supplemental parser has a coverage gap.
+
+## JSON output
+
+Pass `--format=json` before the paths:
+
+```sh
+zsh-lint --format=json scripts/build.zsh example.plugin.zsh > zsh-lint.json
+```
+
+The output is one versioned JSON object with sorted `diagnostics` and a
+`summary`:
+
+```json
+{
+  "version": 1,
+  "diagnostics": [],
+  "summary": {
+    "files": 2,
+    "diagnostics": 0,
+    "errors": 0,
+    "warnings": 0,
+    "infos": 0,
+    "hints": 0
+  }
+}
+```
+
+Parser failures appear as `parse/error` diagnostics. The exit code does not
+change in JSON mode: 0 means no Warning or Error, 1 means a Warning, Error,
+parser failure, or unreadable input, and 2 means a usage or output error.
+
+Machine consumers should reject a JSON `version` they do not understand.

--- a/community/04_zsh_lint/06_troubleshooting.mdx
+++ b/community/04_zsh_lint/06_troubleshooting.mdx
@@ -1,0 +1,66 @@
+---
+id: zsh-lint-troubleshooting
+title: Troubleshooting
+sidebar_position: 7
+description: Resolve common Zsh Lint installation, input, parser, and exit-code problems.
+keywords:
+  - zsh-lint
+  - troubleshooting
+  - parser error
+  - exit code
+---
+
+## `zsh-lint: command not found`
+
+Go normally installs binaries under `$(go env GOPATH)/bin`. Add that directory
+to `PATH`, or invoke the binary directly:
+
+```sh
+"$(go env GOPATH)/bin/zsh-lint" path/to/script.zsh
+```
+
+## Passing a directory fails
+
+The published CLI opens each argument as one file. It does not recurse through
+directories. Build an explicit file list as described in
+[Choosing files](./02_choosing_files.mdx).
+
+## A Bash or `sh` file reports strange parse errors
+
+Zsh Lint does not classify dialects from the shebang or extension. Every path
+you pass is parsed as Zsh. Remove non-Zsh files from the input list.
+
+## Valid Zsh reports a parser error
+
+First check the same file with the supported native Zsh version:
+
+```sh
+zsh -f -n -- path/to/script.zsh
+```
+
+If native Zsh accepts it, collect a minimal example and report a parser gap in
+[z-shell/zsh-lint](https://github.com/z-shell/zsh-lint/issues). Do not rewrite
+valid native Zsh only to satisfy a supplemental parser.
+
+## `--config` is rejected
+
+The option is not available in v1.1.0. It currently exists only on `main`; see
+the [project configuration preview](./03_project_configuration.mdx).
+
+## Exit status 1 with no obvious error
+
+Warnings also return status 1. Read the human diagnostics or save JSON and
+inspect the summary:
+
+```sh
+zsh-lint --format=json path/to/script.zsh | jq '.summary'
+```
+
+Because the linter itself exits 1 for findings, append `|| status=$?` only when
+you are deliberately inspecting output. Do not hide the failure in CI.
+
+## An intentional pattern keeps failing
+
+Read the rule, verify that the code is intentional, then add a line-scoped
+suppression with the exact rule ID and a reason. See
+[Rules and suppressions](./04_rules_and_suppressions.mdx).

--- a/community/04_zsh_lint/07_parser_survey.mdx
+++ b/community/04_zsh_lint/07_parser_survey.mdx
@@ -1,0 +1,43 @@
+---
+id: zsh-lint-parser-survey
+title: Parser survey
+sidebar_position: 8
+description: Survey parser coverage across an explicit Zsh corpus without running lint rules.
+keywords:
+  - zsh-lint-survey
+  - parser
+  - corpus
+  - advanced
+---
+
+`zsh-lint-survey` is an advanced companion command for parser evaluation. It
+answers whether the current parser accepts each explicit input. It does not run
+lint rules and should not replace `zsh-lint` in ordinary CI.
+
+## Install and run
+
+```sh
+go install github.com/z-shell/zsh-lint/cmd/zsh-lint-survey@v1.1.0
+zsh-lint-survey scripts/build.zsh functions/example-run
+```
+
+The command prints parser failures in a greppable form and ends with a summary.
+Like the linter, it does not discover files or classify dialects. Supply a
+reviewed Zsh-only list.
+
+## When to use it
+
+- Evaluate parser coverage before adopting the linter across a large corpus.
+- Reduce a native-Zsh construct that the supplemental parser rejects.
+- Track whether a known parser gap remains reproducible after an update.
+
+Always compare a suspected gap with native Zsh:
+
+```sh
+zsh -f -n -- path/to/source
+zsh-lint-survey path/to/source
+```
+
+If the first command succeeds and the survey fails, native Zsh validity takes
+priority. Report the reduced example rather than changing valid code solely for
+the survey.

--- a/community/04_zsh_lint/08_rule_reference.mdx
+++ b/community/04_zsh_lint/08_rule_reference.mdx
@@ -1,0 +1,344 @@
+---
+id: zsh-lint-rule-reference
+title: Published rule reference
+sidebar_position: 9
+description: Read the Zsh Lint rules generated from the latest published release.
+keywords:
+  - zsh-lint
+  - rules
+  - reference
+  - diagnostics
+toc_max_heading_level: 3
+---
+
+This page is generated from the documented rules in the latest published
+Zsh Lint release. Start with [Rules and suppressions](./04_rules_and_suppressions.mdx)
+if you are new to diagnostics and intentional exceptions.
+
+Do not hand-edit the marked region. The source repository's release-aligned
+documentation workflow replaces it automatically.
+
+{/* zsh-lint:generated:start */}
+
+:::info Published rule set
+This reference was generated from the published `v1.1.0` release at commit [`fde7795feaa65a222acf42459a26eb0f9271523d`](https://github.com/z-shell/zsh-lint/commit/fde7795feaa65a222acf42459a26eb0f9271523d). It matches the rules users receive from `go install github.com/z-shell/zsh-lint/cmd/zsh-lint@v1.1.0`.
+:::
+
+## Rules
+
+- [`compat/special-param-shadow`](#rule-compatspecial-param-shadow): Shadowing special shell parameters
+- [`plugin/fpath-hygiene`](#rule-pluginfpath-hygiene): fpath manipulation hygiene in plugin entrypoints
+- [`plugin/function-scoped-options`](#rule-pluginfunction-scoped-options): Function files should scope shell options
+- [`plugin/unload-function`](#rule-pluginunload-function): Unload function convention and hygiene
+- [`plugin/zero-handling`](#rule-pluginzero-handling): Zero-handling idiom in plugin entrypoint
+- [`quoting/unquoted-var`](#rule-quotingunquoted-var): Unquoted variable expansion
+- [`security/eval`](#rule-securityeval): Use of eval
+- [`style/backquotes`](#rule-stylebackquotes): Prefer dollar-parenthesis command substitution
+- [`style/function-decl`](#rule-stylefunction-decl): Function declaration style
+- [`style/prefer-double-brackets`](#rule-styleprefer-double-brackets): Prefer \[\[ \]\] over \[ \] or test
+
+## Rule: `compat/special-param-shadow`
+
+**Name:** Shadowing special shell parameters
+
+**Summary:** Reports `local`, `typeset`, `declare`, or `readonly` declarations of a curated set of shell-set parameters (for example `ZSH_VERSION`, `OSTYPE`, and `pipestatus`); explicit non-local `-g` declarations (including `readonly -g`), the `export` builtin, and `typeset`-family query/display/function modes (standalone `+`, `-p`/`+p`, `+m`, and `-f`/`+f`) are excluded. Pattern declarations with `-m` are reported only when an effective `+g` makes matching non-local parameters local. The rule also stays silent when dynamic option words or the ambient `GLOBAL_EXPORT` option make declaration scope uncertain. Reads are never reported.
+
+Why: The Zsh manual's zshparam "Parameters Set By The Shell" section documents these as shell-provided state. In a function, `readonly` is `typeset -r` and creates a local binding unless `-g` explicitly selects non-local behavior. Version probes such as `is-at-least $ZSH_VERSION` are pervasive in plugin code, so a `local ZSH_VERSION=...` in a caller silently feeds the override to all nested code for the lifetime of the scope. At top level, the same declaration form clobbers the shell-managed outer binding instead of creating a temporary local. Unlike ordinary shadowing, the reader has no declaration of the original to look up -- the shell set it. See https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Set-By-The-Shell.
+
+**Bad:**
+
+```zsh
+compile_zsh() {
+  local ZSH_VERSION="$1"
+}
+```
+
+**Good:**
+
+```zsh
+compile_zsh() {
+  local target_zsh_version="$1"
+}
+```
+
+**Severity:** Warning. The pattern is functional but misleading and can change what nested code observes; deliberate compatibility shims are realistic, so it is suppressible rather than an error.
+
+False positives: Deliberate compatibility shims or test harnesses that fake `ZSH_VERSION` or `OSTYPE` for downstream code are the rule's target behavior made intentional; suppress them with a reason. The rule flags only a curated allowlist of read-mostly shell-set parameters and stays silent for reads and the conventionally mutated `path`, `fpath`, `PATH`, `REPLY`, and `match`. The shell-special `status` and `pipestatus` cases remain included because `local -h status=...` and `local -h pipestatus=(...)` can replace their special behavior with ordinary local bindings.
+
+**Suppression:** Use `# zsh-lint disable=compat/special-param-shadow -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: Issue #64 records `zd/docker/utils.zsh:78`: `local ZSH_VERSION="$1"` inside a helper that takes a target version as its first argument. Deferred issue #72 tracks bare assignments in function scope and `integer`/`float` declarations; both are out of scope for this rule version.
+
+## Rule: `plugin/fpath-hygiene`
+
+**Name:** fpath manipulation hygiene in plugin entrypoints
+
+**Summary:** Detects destructive assignments to `fpath` that overwrite existing autoload paths, additions of non-function directories (`bin/`, `tests/`), and hardcoded user paths.
+
+Why: Sourced Zsh plugins must not destructively replace `fpath` (which removes standard system and user function directories), add hardcoded user machine paths, or add non-function directories (`bin/`, `tests/`) that can trigger completion security audit warnings (`compaudit`) or namespace collisions. Plugins should append or prepend relative `functions/` or `completions/` directories. See https://wiki.zshell.dev/community/zsh_plugin_standard#completions-and-compinit-ownership.
+
+**Bad:**
+
+```zsh
+#### Destructively overwrites existing autoload paths
+fpath=( "${0:h}/functions" )
+
+#### Adds binary directory to fpath
+fpath+=( "${0:h}/bin" )
+```
+
+**Good:**
+
+```zsh
+fpath+=( "${0:h}/functions" "${0:h}/completions" )
+
+#### Prepending while preserving existing paths
+fpath=( "${0:h}/functions" $fpath )
+```
+
+**Severity:** Warning for destructive `fpath` overwrites or additions of `bin`/`tests` directories to `fpath`.
+
+False positives: Hermetic test runners or standalone shell bootstrap scripts that deliberately isolate `fpath`. Suppress with a reason.
+
+**Suppression:** Use `# zsh-lint disable=plugin/fpath-hygiene -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:12` uses compliant `fpath+=( "${0:h}/functions" )`.
+
+## Rule: `plugin/function-scoped-options`
+
+**Name:** Function files should scope shell options
+
+**Summary:** Reports executable files beneath a `functions` directory when neither `builtin emulate -L zsh` nor `setopt local_options` appears before the first non-guard top-level statement.
+
+Why: Zsh functions inherit the caller's option state. The Zsh manual documents `LOCAL_OPTIONS` as restoring options on function return, while `emulate -L` both selects Zsh emulation and makes option changes local. Without either form, options such as `SH_WORD_SPLIT`, `KSH_ARRAYS`, or `NO_EXTENDED_GLOB` can silently change function behavior. See https://zsh.sourceforge.io/Doc/Release/Options.html#index-LOCAL_005fOPTIONS and https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-emulate.
+
+**Bad:**
+
+```zsh
+local -a matches
+matches=( $~pattern )
+```
+
+**Good:**
+
+```zsh
+builtin emulate -L zsh
+local -a matches
+matches=( $~pattern )
+```
+
+**Severity:** Hint. Missing option scoping enables latent caller-dependent bugs, but some helper functions intentionally inspect or mutate caller option state.
+
+False positives: Functions that intentionally share caller option state and trivial single-builtin functions remain findings by design; suppress them with a reason. Files outside a complete `functions` path segment are out of scope. A contiguous prefix of recognized `condition || return` or single-return `if` guards is accepted before scoping.
+
+**Suppression:** Use `# zsh-lint disable=plugin/function-scoped-options -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: Issue #63 reported missing scoping across z-a-meta-plugins and zsh-fancy-completions function files. The analyzer currently flags `zsh-fancy-completions/functions/.completion-prediction` and `zsh-fancy-completions/functions/.force_rehash`. The originally cited `z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd-help-handler` is a fully commented-out stub and is correctly silent. Compliant `setopt local_options` and `builtin emulate -L zsh` examples exist in the same repositories.
+
+## Rule: `plugin/unload-function`
+
+**Name:** Unload function convention and hygiene
+
+**Summary:** Checks that plugins registering persistent shell hooks or widgets define a namespaced unload function (`*_plugin_unload`), and that defined unload functions cleanly unfunction themselves upon completion.
+
+Why: The Zsh Plugin Standard specifies that plugins with persistent side effects (hooks via `add-zsh-hook`, line-editor widgets via `add-zle-hook-widget` or `zle -N`) should provide a namespaced `*_plugin_unload` function so plugin managers and users can cleanly unload the plugin without restarting the shell. The unload function must explicitly remove only its own resources and unfunction itself upon completion. See https://wiki.zshell.dev/community/zsh_plugin_standard#lifecycle-and-resource-ownership.
+
+**Bad:**
+
+```zsh
+#### Plugin installs hook but provides no unload function
+add-zsh-hook precmd _my_precmd
+```
+
+**Good:**
+
+```zsh
+add-zsh-hook precmd _my_precmd
+
+my_plugin_unload() {
+  emulate -L zsh
+  autoload -Uz add-zsh-hook
+  add-zsh-hook -d precmd _my_precmd
+  unfunction _my_precmd my_plugin_unload
+}
+```
+
+**Severity:** Hint. Missing unload functions or self-unfunction in unload definitions are lifecycle recommendations. Indiscriminate function wiping is a Warning.
+
+False positives: Plugins intended only for static, once-per-session loading without unload support. Suppress with a reason.
+
+**Suppression:** Use `# zsh-lint disable=plugin/unload-function -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: `zsh-fancy-completions/lib/state.zsh:72` implements `zsh-fancy-completions_plugin_unload` with full resource restoration and self-unfunction.
+
+## Rule: `plugin/zero-handling`
+
+**Name:** Zero-handling idiom in plugin entrypoint
+
+**Summary:** Reports direct uses of `$0` at the top level of plugin scripts before `$0` has been initialized using prompt expansions (`${(%):-%N}` or `${(%):-%x}`).
+
+Why: When a Zsh plugin is sourced, positional parameter `$0` evaluates to the name of the shell (`zsh` or `-zsh`) rather than the path of the sourced script, unless `FUNCTION_ARGZERO` is active. Plugin entrypoints must initialize `$0` using prompt expansion `${(%):-%N}` or `${(%):-%x}` (optionally with `$ZERO` fallback) before using `$0` to derive directories or autoload paths. See https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling.
+
+**Bad:**
+
+```zsh
+fpath+=( "${0:h}/functions" )
+```
+
+**Good:**
+
+```zsh
+0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+fpath+=( "${0:h}/functions" )
+```
+
+**Severity:** Warning. Deriving paths from uninitialized `$0` in a sourced plugin leads to incorrect directory paths or runtime loading failures.
+
+False positives: Scripts intended solely for direct execution (not sourcing) or functions where `$0` refers to the function name. Suppress with a reason.
+
+**Suppression:** Use `# zsh-lint disable=plugin/zero-handling -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7` uses the compliant `0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"` idiom before referencing `${0:h}` on line 12.
+
+## Rule: `quoting/unquoted-var`
+
+**Name:** Unquoted variable expansion
+
+**Summary:** Reports parameter expansions in command names or arguments that are not enclosed in double quotes.
+
+Why: The Zsh manual's Parameter Expansion section explains that unquoted parameters are not split on whitespace by default, unlike in sh, but null words are still elided; enabling `SH_WORD_SPLIT` also makes unquoted values subject to field splitting. Double quotes preserve an empty scalar as an argument and keep the expansion single-word under either option state. See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion.
+
+**Bad:**
+
+```zsh
+print -r -- $value
+```
+
+**Good:**
+
+```zsh
+print -r -- "$value"
+```
+
+**Severity:** Warning. Losing an empty argument or inheriting `SH_WORD_SPLIT` can change command behavior, while intentional elision remains realistic.
+
+False positives: Code may intentionally omit an empty argument, deliberately rely on `SH_WORD_SPLIT`, or expand a value guaranteed to be non-empty. Those cases should use a reasoned suppression rather than weakening unrelated diagnostics.
+
+**Suppression:** Use `# zsh-lint disable=quoting/unquoted-var -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: Sourced scripts and plugin entrypoints frequently use quoted parameters for scalar configuration and path derivation.
+
+## Rule: `security/eval`
+
+**Name:** Use of eval
+
+**Summary:** Reports commands whose literal command name is `eval`.
+
+Why: The Zsh manual documents that `eval` reads its arguments as shell input and executes the resulting commands in the current shell process. Dynamic or untrusted text can therefore become shell syntax rather than inert data. See https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-eval.
+
+**Bad:**
+
+```zsh
+eval "print -r -- $user_input"
+```
+
+**Good:**
+
+```zsh
+print -r -- "$user_input"
+```
+
+**Severity:** Info. Re-evaluating dynamic input is risky, but deliberate uses such as trusted code generation and compatibility shims are common enough that the pattern is not automatically a bug.
+
+False positives: Static, maintainer-controlled command strings and deliberate shell-language adapters may require `eval`. Keep the finding visible unless the trust boundary is documented next to the call.
+
+**Suppression:** Use `# zsh-lint disable=security/eval -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line. A reason is strongly recommended for this security-category rule.
+
+Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
+
+## Rule: `style/backquotes`
+
+**Name:** Prefer dollar-parenthesis command substitution
+
+**Summary:** Reports the grave-accent form of command substitution in favor of `$()`.
+
+Why: The Zsh manual's Command Substitution section documents both `$()` and grave accents as supported forms. This rule prefers `$()` as the clearer, readily nestable modern idiom; it does not claim grave accents are invalid Zsh syntax. See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Command-Substitution.
+
+**Bad:**
+
+```zsh
+current=`pwd`
+```
+
+**Good:**
+
+```zsh
+current=$(pwd)
+```
+
+**Severity:** Hint. The forms are semantically supported; this is an idiom and readability preference rather than a correctness diagnostic.
+
+False positives: A project may intentionally preserve historical style or mirror code shared with an environment where that spelling is required.
+
+**Suppression:** Use `# zsh-lint disable=style/backquotes -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
+
+## Rule: `style/function-decl`
+
+**Name:** Function declaration style
+
+**Summary:** Reports declarations written as `function name()` instead of choosing either `name()` or `function name`.
+
+Why: The Zsh manual's Complex Commands grammar documents the sh-compatible `word ()` form and the Zsh `function word` form as alternatives. Combining both spellings is accepted but redundant, so choosing one form communicates the intended style more clearly. See https://zsh.sourceforge.io/Doc/Release/Shell-Grammar.html#Complex-Commands.
+
+**Bad:**
+
+```zsh
+function render() { print ok; }
+```
+
+**Good:**
+
+```zsh
+render() { print ok; }
+```
+
+**Severity:** Hint. The mixed declaration is valid Zsh and the suggested change is stylistic.
+
+False positives: Generated code or a project-wide convention may intentionally use the mixed spelling even though Zsh does not require it.
+
+**Suppression:** Use `# zsh-lint disable=style/function-decl -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
+
+## Rule: `style/prefer-double-brackets`
+
+**Name:** Prefer \[\[ \]\] over \[ \] or test
+
+**Summary:** Reports literal `[` and `test` command names in favor of Zsh's `[[ ... ]]` compound command.
+
+Why: The Zsh manual's Conditional Expressions section documents that expansions inside `[[ ... ]]` are constrained to one word and do not perform filename generation. With `[` or `test`, normal command-line globbing can produce multiple words and confuse the test command's syntax. See https://zsh.sourceforge.io/Doc/Release/Conditional-Expressions.html.
+
+**Bad:**
+
+```zsh
+if [ "$name" = *.zsh ]; then print match; fi
+```
+
+**Good:**
+
+```zsh
+if [[ $name = *.zsh ]]; then print match; fi
+```
+
+**Severity:** Hint. `[` and `test` remain valid commands; the rule recommends the safer and more expressive Zsh-native conditional syntax.
+
+False positives: Scripts intentionally kept portable across POSIX shells, or code that explicitly needs `test` command semantics, should retain the portable form and document the choice.
+
+**Suppression:** Use `# zsh-lint disable=style/prefer-double-brackets -- <reason>` on the finding line or immediately before the next non-comment, non-blank source line.
+
+Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
+
+{/* zsh-lint:generated:end */}

--- a/community/04_zsh_lint/index.mdx
+++ b/community/04_zsh_lint/index.mdx
@@ -2,1049 +2,128 @@
 id: zsh_lint
 title: 🔍 Zsh Lint
 sidebar_position: 1
-description: A Go-based semantic analyzer for Zsh.
+description: Start using Zsh Lint, understand which files it checks, and find focused guides.
 keywords:
   - zsh-lint
-  - linter
   - zsh
-  - go
+  - static analysis
+  - linting
 ---
 
 {/* @format */}
 
-## A Go-based semantic analyzer for Zsh
+`zsh-lint` is a standalone semantic analyzer for Zsh. Give it one or more
+source-file paths and it reports parser errors, correctness problems, and
+advisory findings in a greppable format.
 
-`zsh-lint` is a standalone Go semantic analyzer for Zsh. It parses Zsh sources
-with a real grammar front end and reports greppable diagnostics from its default
-static-analysis rules.
+## Try it in five minutes
 
-### <i class="fa-brands fa-github"></i> [z-shell/zsh-lint][]
-
-### Installation
+Install the current published release with an exact version:
 
 ```sh
-go install github.com/z-shell/zsh-lint/cmd/zsh-lint@latest
+go install github.com/z-shell/zsh-lint/cmd/zsh-lint@v1.1.0
 ```
 
-### Usage
-
-```sh
-zsh-lint path/to/file.zsh another.zsh
-```
-
-Diagnostics use the `path:line:col: [rule-id] message` format. Parse errors,
-warnings, and errors produce a non-zero exit code.
-
-For parser-gap corpus evaluation without static-analysis rules, use the
-dedicated survey command:
+Then check a file:
 
 ```sh
-zsh-lint-survey path/to/file.zsh another.zsh
-```
-
-### Reference
-
-{/* zsh-lint:generated:start */}
-
-
-
-#### zsh\-lint
-
-```go
-import "github.com/z-shell/zsh-lint/cmd/zsh-lint"
-```
-
-Command zsh\-lint performs static analysis of Zsh shell scripts.
-
-##### Index
-
-
-
-#### zsh\-lint\-survey
-
-```go
-import "github.com/z-shell/zsh-lint/cmd/zsh-lint-survey"
-```
-
-Command zsh\-lint\-survey runs the parser front end across Zsh files and reports parser gaps without evaluating static\-analysis rules.
-
-##### Index
-
-
-
-#### survey
-
-```go
-import "github.com/z-shell/zsh-lint/internal/survey"
-```
-
-Package survey runs the parser front end across a set of Zsh files and reports, per file, whether parsing succeeded. It produces greppable `path:line:col: message` diagnostics for failures and a one\-line summary.
-
-This is the reboot's parser\-evaluation surface \(issues \#5, \#8\): it reports parser outcomes only and intentionally implements no lint rules yet.
-
-##### Index
-
-- [func Run\(names \[\]string, w io.Writer\) int](#func-run)
-
-
-
-##### func Run
-
-```go
-func Run(names []string, w io.Writer) int
-```
-
-Run parses each file in names, writing per\-file status and a summary to w.
-
-Each file produces either an "OK \&lt;path\&gt;" line or a "FAIL \&lt;path\&gt;" line followed by a greppable "\&lt;path\&gt;:\&lt;line\&gt;:\&lt;col\&gt;: \&lt;message\&gt;" diagnostic. A final summary line reports the total number of files surveyed, ok, and failed.
-
-It returns a process exit code: 0 if every file parsed, 1 otherwise.
-
-#### rules
-
-```go
-import "github.com/z-shell/zsh-lint/internal/rules"
-```
-
-##### Index
-
-- [func Default\(\) \[\]analyzer.Rule](#func-default)
-- [func ForProfile\(profile Profile\) \(\[\]analyzer.Rule, error\)](#func-forprofile)
-- [type Backquotes](#type-backquotes)
-  - [func \(r Backquotes\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-backquotes-analyze)
-  - [func \(r Backquotes\) ID\(\) diag.RuleID](#func-backquotes-id)
-  - [func \(r Backquotes\) Name\(\) string](#func-backquotes-name)
-- [type EvalUsage](#type-evalusage)
-  - [func \(r EvalUsage\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-evalusage-analyze)
-  - [func \(r EvalUsage\) ID\(\) diag.RuleID](#func-evalusage-id)
-  - [func \(r EvalUsage\) Name\(\) string](#func-evalusage-name)
-- [type FpathHygiene](#type-fpathhygiene)
-  - [func \(rule FpathHygiene\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-fpathhygiene-analyze)
-  - [func \(FpathHygiene\) ID\(\) diag.RuleID](#func-fpathhygiene-id)
-  - [func \(FpathHygiene\) Name\(\) string](#func-fpathhygiene-name)
-- [type FuncDeclStyle](#type-funcdeclstyle)
-  - [func \(r FuncDeclStyle\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-funcdeclstyle-analyze)
-  - [func \(r FuncDeclStyle\) ID\(\) diag.RuleID](#func-funcdeclstyle-id)
-  - [func \(r FuncDeclStyle\) Name\(\) string](#func-funcdeclstyle-name)
-- [type FunctionNamespace](#type-functionnamespace)
-  - [func \(rule FunctionNamespace\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-functionnamespace-analyze)
-  - [func \(rule FunctionNamespace\) AnalyzeFile\(ctx \*analyzer.Context\)](#func-functionnamespace-analyzefile)
-  - [func \(FunctionNamespace\) ID\(\) diag.RuleID](#func-functionnamespace-id)
-  - [func \(FunctionNamespace\) Name\(\) string](#func-functionnamespace-name)
-- [type FunctionScopedOptions](#type-functionscopedoptions)
-  - [func \(rule FunctionScopedOptions\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-functionscopedoptions-analyze)
-  - [func \(FunctionScopedOptions\) ID\(\) diag.RuleID](#func-functionscopedoptions-id)
-  - [func \(FunctionScopedOptions\) Name\(\) string](#func-functionscopedoptions-name)
-- [type PreferDoubleBrackets](#type-preferdoublebrackets)
-  - [func \(r PreferDoubleBrackets\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-preferdoublebrackets-analyze)
-  - [func \(r PreferDoubleBrackets\) ID\(\) diag.RuleID](#func-preferdoublebrackets-id)
-  - [func \(r PreferDoubleBrackets\) Name\(\) string](#func-preferdoublebrackets-name)
-- [type Profile](#type-profile)
-- [type ProjectUnloadLifecycle](#type-projectunloadlifecycle)
-  - [func \(ProjectUnloadLifecycle\) Analyze\(\_ \*analyzer.Context, \_ syntax.Node\)](#func-projectunloadlifecycle-analyze)
-  - [func \(rule ProjectUnloadLifecycle\) AnalyzeProject\(ctx \*analyzer.ProjectContext\)](#func-projectunloadlifecycle-analyzeproject)
-  - [func \(ProjectUnloadLifecycle\) ID\(\) diag.RuleID](#func-projectunloadlifecycle-id)
-  - [func \(ProjectUnloadLifecycle\) Name\(\) string](#func-projectunloadlifecycle-name)
-- [type RepeatedExternalCommand](#type-repeatedexternalcommand)
-  - [func \(rule RepeatedExternalCommand\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-repeatedexternalcommand-analyze)
-  - [func \(RepeatedExternalCommand\) ID\(\) diag.RuleID](#func-repeatedexternalcommand-id)
-  - [func \(RepeatedExternalCommand\) Name\(\) string](#func-repeatedexternalcommand-name)
-- [type SpecialParamShadow](#type-specialparamshadow)
-  - [func \(rule SpecialParamShadow\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-specialparamshadow-analyze)
-  - [func \(SpecialParamShadow\) ID\(\) diag.RuleID](#func-specialparamshadow-id)
-  - [func \(SpecialParamShadow\) Name\(\) string](#func-specialparamshadow-name)
-- [type UnloadFunction](#type-unloadfunction)
-  - [func \(rule UnloadFunction\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-unloadfunction-analyze)
-  - [func \(UnloadFunction\) ID\(\) diag.RuleID](#func-unloadfunction-id)
-  - [func \(UnloadFunction\) Name\(\) string](#func-unloadfunction-name)
-- [type UnquotedVar](#type-unquotedvar)
-  - [func \(r UnquotedVar\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-unquotedvar-analyze)
-  - [func \(r UnquotedVar\) ID\(\) diag.RuleID](#func-unquotedvar-id)
-  - [func \(r UnquotedVar\) Name\(\) string](#func-unquotedvar-name)
-- [type ZeroHandling](#type-zerohandling)
-  - [func \(rule ZeroHandling\) Analyze\(ctx \*analyzer.Context, node syntax.Node\)](#func-zerohandling-analyze)
-  - [func \(ZeroHandling\) ID\(\) diag.RuleID](#func-zerohandling-id)
-  - [func \(ZeroHandling\) Name\(\) string](#func-zerohandling-name)
-
-
-
-##### func Default
-
-```go
-func Default() []analyzer.Rule
-```
-
-Default returns the default set of static analysis rules.
-
-
-##### func ForProfile
-
-```go
-func ForProfile(profile Profile) ([]analyzer.Rule, error)
-```
-
-ForProfile returns the complete rule set associated with a configured rule profile. Unknown profiles fail explicitly rather than silently disabling configured rules.
-
-
-##### type Backquotes
-
-Backquotes reports grave\-accent command substitutions.
-
-ID: `style/backquotes`
-
-Name: Prefer dollar\-parenthesis command substitution
-
-Summary: Reports the grave\-accent form of command substitution in favor of `$()`.
-
-Why: The Zsh manual's Command Substitution section documents both `$()` and grave accents as supported forms. This rule prefers `$()` as the clearer, readily nestable modern idiom; it does not claim grave accents are invalid Zsh syntax. See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Command-Substitution.
-
-Bad:
-
-```zsh
-current=`pwd`
-```
-
-Good:
-
-```zsh
-current=$(pwd)
-```
-
-Severity: Hint. The forms are semantically supported; this is an idiom and readability preference rather than a correctness diagnostic.
-
-False positives: A project may intentionally preserve historical style or mirror code shared with an environment where that spelling is required.
-
-Suppression: Use `# zsh-lint disable=style/backquotes -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: The June 12, 2026 LangZsh clean\-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
-
-```go
-type Backquotes struct{}
-```
-
-
-###### func \(Backquotes\) Analyze
-
-```go
-func (r Backquotes) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(Backquotes\) ID
-
-```go
-func (r Backquotes) ID() diag.RuleID
-```
-
-
-
-
-###### func \(Backquotes\) Name
-
-```go
-func (r Backquotes) Name() string
-```
-
-
-
-
-##### type EvalUsage
-
-EvalUsage reports calls to the `eval` shell builtin.
-
-ID: `security/eval`
-
-Name: Use of eval
-
-Summary: Reports commands whose literal command name is `eval`.
-
-Why: The Zsh manual documents that `eval` reads its arguments as shell input and executes the resulting commands in the current shell process. Dynamic or untrusted text can therefore become shell syntax rather than inert data. See https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-eval.
-
-Bad:
-
-```zsh
-eval "print -r -- $user_input"
-```
-
-Good:
-
-```zsh
-print -r -- "$user_input"
-```
-
-Severity: Info. Re\-evaluating dynamic input is risky, but deliberate uses such as trusted code generation and compatibility shims are common enough that the pattern is not automatically a bug.
-
-False positives: Static, maintainer\-controlled command strings and deliberate shell\-language adapters may require `eval`. Keep the finding visible unless the trust boundary is documented next to the call.
-
-Suppression: Use `# zsh-lint disable=security/eval -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line. A reason is strongly recommended for this security\-category rule.
-
-Corpus evidence: The June 12, 2026 LangZsh clean\-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
-
-```go
-type EvalUsage struct{}
-```
-
-
-###### func \(EvalUsage\) Analyze
-
-```go
-func (r EvalUsage) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(EvalUsage\) ID
-
-```go
-func (r EvalUsage) ID() diag.RuleID
-```
-
-
-
-
-###### func \(EvalUsage\) Name
-
-```go
-func (r EvalUsage) Name() string
-```
-
-
-
-
-##### type FpathHygiene
-
-FpathHygiene checks `fpath` modifications in plugin scripts for safety and best practices.
-
-ID: `plugin/fpath-hygiene`
-
-Name: fpath manipulation hygiene in plugin entrypoints
-
-Summary: In configured plugin and Zi annex sourced\-library entrypoints, detects destructive assignments to `fpath` that overwrite existing autoload paths, additions of non\-function directories \(`bin/`, `tests/`\), and hardcoded user paths. Unconfigured analysis retains its legacy applicability.
-
-Why: Sourced Zsh plugins must not destructively replace `fpath` \(which removes standard system and user function directories\), add hardcoded user machine paths, or add non\-function directories \(`bin/`, `tests/`\) that can trigger completion security audit warnings \(`compaudit`\) or namespace collisions. Plugins should append or prepend relative `functions/` or `completions/` directories. See https://wiki.zshell.dev/community/zsh_plugin_standard#completions-and-compinit-ownership.
-
-Bad:
-
-```zsh
-#### Destructively overwrites existing autoload paths
-fpath=( "${0:h}/functions" )
-
-#### Adds binary directory to fpath
-fpath+=( "${0:h}/bin" )
-```
-
-Good:
-
-```zsh
-fpath+=( "${0:h}/functions" "${0:h}/completions" )
-
-#### Prepending while preserving existing paths
-fpath=( "${0:h}/functions" $fpath )
-```
-
-Severity: Warning for destructive `fpath` overwrites or additions of `bin`/`tests` directories to `fpath`.
-
-False positives: Hermetic test runners or standalone shell bootstrap scripts that deliberately isolate `fpath`. Suppress with a reason.
-
-Suppression: Use `# zsh-lint disable=plugin/fpath-hygiene -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:12` uses compliant `fpath+=( "${0:h}/functions" )`.
-
-```go
-type FpathHygiene struct{}
-```
-
-
-###### func \(FpathHygiene\) Analyze
-
-```go
-func (rule FpathHygiene) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(FpathHygiene\) ID
-
-```go
-func (FpathHygiene) ID() diag.RuleID
-```
-
-
-
-
-###### func \(FpathHygiene\) Name
-
-```go
-func (FpathHygiene) Name() string
-```
-
-
-
-
-##### type FuncDeclStyle
-
-FuncDeclStyle reports function declarations that combine `function` and `()`.
-
-ID: `style/function-decl`
-
-Name: Function declaration style
-
-Summary: Reports declarations written as `function name()` instead of choosing either `name()` or `function name`.
-
-Why: The Zsh manual's Complex Commands grammar documents the sh\-compatible `word ()` form and the Zsh `function word` form as alternatives. Combining both spellings is accepted but redundant, so choosing one form communicates the intended style more clearly. See https://zsh.sourceforge.io/Doc/Release/Shell-Grammar.html#Complex-Commands.
-
-Bad:
-
-```zsh
-function render() { print ok; }
-```
-
-Good:
-
-```zsh
-render() { print ok; }
-```
-
-Severity: Hint. The mixed declaration is valid Zsh and the suggested change is stylistic.
-
-False positives: Generated code or a project\-wide convention may intentionally use the mixed spelling even though Zsh does not require it.
-
-Suppression: Use `# zsh-lint disable=style/function-decl -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: The June 12, 2026 LangZsh clean\-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
-
-```go
-type FuncDeclStyle struct{}
-```
-
-
-###### func \(FuncDeclStyle\) Analyze
-
-```go
-func (r FuncDeclStyle) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(FuncDeclStyle\) ID
-
-```go
-func (r FuncDeclStyle) ID() diag.RuleID
-```
-
-
-
-
-###### func \(FuncDeclStyle\) Name
-
-```go
-func (r FuncDeclStyle) Name() string
-```
-
-
-
-
-##### type FunctionNamespace
-
-FunctionNamespace reports persistent plugin function names outside the configured stable project namespace.
-
-ID: `plugin/function-namespace`
-
-Name: Project\-owned function namespace
-
-Summary: Reports named functions in configured plugin and Zi annex source files, plus effective function names derived from configured autoload file basenames, when they do not use an explicitly declared project namespace.
-
-Why: The Zsh Plugin Standard requires persistent shell\-visible names to use a stable project identifier. Namespacing prevents collisions when unrelated plugins share one shell process. Native completions keep Zsh's `_command` convention, and the established `.`, `→`, `+`, `/`, and `@` role prefixes remain valid before the project namespace. The portable `_example_callback` form is also accepted. See https://wiki.zshell.dev/community/zsh_plugin_standard#names-and-persistent-state and https://wiki.zshell.dev/community/zsh_plugin_standard#standard-function-name-space-prefixes.
-
-Bad:
-
-```zsh
-refresh() { builtin emulate -L zsh; }
-```
-
-Good:
-
-```zsh
-example_refresh() { builtin emulate -L zsh; }
-_example_precmd() { builtin emulate -L zsh; }
-```
-
-Severity: Hint. A mismatched namespace is an interoperability and hygiene concern, not invalid Zsh syntax.
-
-False positives: The rule runs only with version 1 project configuration, a plugin or Zi annex project kind, a sourced\-library or autoload\-function source profile, and at least one explicit function namespace. Completion basenames use `_command` only when the source role is `completion`. Repository names and directory names are never inferred as namespaces.
-
-Suppression: Use `# zsh-lint disable=plugin/function-namespace -- <reason>` on a declaration line or immediately before it. For an autoload basename finding, put the standalone directive in the file header before any source code.
-
-Corpus evidence: `zsh-eza/functions/.zsh-eza` and the `z-a-meta-plugins/functions/.za-meta-plugins-*` files use their configured namespaces. `zsh-fancy-completions/lib/state.zsh` uses its explicit `zfc` namespace. Its five legacy dot\-prefixed autoload basenames \(`.complete_menu`, `.completion-prediction`, `.expand-or-complete-with-dots`, `.force_rehash`, and `.man_glob`\) are classified as true\-positive Hint findings. Advisory rollout does not require renaming those established external interfaces.
-
-```go
-type FunctionNamespace struct{}
-```
-
-
-###### func \(FunctionNamespace\) Analyze
-
-```go
-func (rule FunctionNamespace) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(FunctionNamespace\) AnalyzeFile
-
-```go
-func (rule FunctionNamespace) AnalyzeFile(ctx *analyzer.Context)
-```
-
-AnalyzeFile checks the effective function name supplied by an autoload file basename. It deliberately reports an unpositioned diagnostic because no AST token represents that name.
-
-
-###### func \(FunctionNamespace\) ID
-
-```go
-func (FunctionNamespace) ID() diag.RuleID
-```
-
-
-
-
-###### func \(FunctionNamespace\) Name
-
-```go
-func (FunctionNamespace) Name() string
-```
-
-
-
-
-##### type FunctionScopedOptions
-
-FunctionScopedOptions reports autoloadable function files that execute logic before localizing inherited shell options.
-
-ID: `plugin/function-scoped-options`
-
-Name: Function files should scope shell options
-
-Summary: For configured plugin and Zi annex projects, reports autoload function sources when neither `builtin emulate -L zsh` nor `setopt local_options` appears before the first non\-guard top\-level statement. Unconfigured analysis retains the legacy `functions` path heuristic.
-
-Why: Zsh functions inherit the caller's option state. The Zsh manual documents `LOCAL_OPTIONS` as restoring options on function return, while `emulate -L` both selects Zsh emulation and makes option changes local. Without either form, options such as `SH_WORD_SPLIT`, `KSH_ARRAYS`, or `NO_EXTENDED_GLOB` can silently change function behavior. See https://zsh.sourceforge.io/Doc/Release/Options.html#index-LOCAL_005fOPTIONS and https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-emulate.
-
-Bad:
-
-```zsh
-local -a matches
-matches=( $~pattern )
-```
-
-Good:
-
-```zsh
-builtin emulate -L zsh
-local -a matches
-matches=( $~pattern )
-```
-
-Severity: Hint. Missing option scoping enables latent caller\-dependent bugs, but some helper functions intentionally inspect or mutate caller option state.
-
-False positives: Functions that intentionally share caller option state and trivial single\-builtin functions remain findings by design; suppress them with a reason. Files outside a complete `functions` path segment are out of scope. A contiguous prefix of recognized `condition || return` or single\-return `if` guards is accepted before scoping.
-
-Suppression: Use `# zsh-lint disable=plugin/function-scoped-options -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: Issue \#63 reported missing scoping across z\-a\-meta\-plugins and zsh\-fancy\-completions function files. The analyzer currently flags `zsh-fancy-completions/functions/.completion-prediction` and `zsh-fancy-completions/functions/.force_rehash`. The originally cited `z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd-help-handler` is a fully commented\-out stub and is correctly silent. Compliant `setopt local_options` and `builtin emulate -L zsh` examples exist in the same repositories.
-
-```go
-type FunctionScopedOptions struct{}
-```
-
-
-###### func \(FunctionScopedOptions\) Analyze
-
-```go
-func (rule FunctionScopedOptions) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(FunctionScopedOptions\) ID
-
-```go
-func (FunctionScopedOptions) ID() diag.RuleID
-```
-
-
-
-
-###### func \(FunctionScopedOptions\) Name
-
-```go
-func (FunctionScopedOptions) Name() string
-```
-
-
-
-
-##### type PreferDoubleBrackets
-
-PreferDoubleBrackets reports `[` and `test` conditional commands.
-
-ID: `style/prefer-double-brackets`
-
-Name: Prefer \[\[ \]\] over \[ \] or test
-
-Summary: Reports literal `[` and `test` command names in favor of Zsh's `[[ ... ]]` compound command.
-
-Why: The Zsh manual's Conditional Expressions section documents that expansions inside `[[ ... ]]` are constrained to one word and do not perform filename generation. With `[` or `test`, normal command\-line globbing can produce multiple words and confuse the test command's syntax. See https://zsh.sourceforge.io/Doc/Release/Conditional-Expressions.html.
-
-Bad:
-
-```zsh
-if [ "$name" = *.zsh ]; then print match; fi
-```
-
-Good:
-
-```zsh
-if [[ $name = *.zsh ]]; then print match; fi
-```
-
-Severity: Hint. `[` and `test` remain valid commands; the rule recommends the safer and more expressive Zsh\-native conditional syntax.
-
-False positives: Scripts intentionally kept portable across POSIX shells, or code that explicitly needs `test` command semantics, should retain the portable form and document the choice.
-
-Suppression: Use `# zsh-lint disable=style/prefer-double-brackets -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: The June 12, 2026 LangZsh clean\-baseline run produced zero findings from this rule across the 11 parseable corpus files. This grandfathered rule therefore has no positive corpus citation yet.
-
-```go
-type PreferDoubleBrackets struct{}
-```
-
-
-###### func \(PreferDoubleBrackets\) Analyze
-
-```go
-func (r PreferDoubleBrackets) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(PreferDoubleBrackets\) ID
-
-```go
-func (r PreferDoubleBrackets) ID() diag.RuleID
-```
-
-
-
-
-###### func \(PreferDoubleBrackets\) Name
-
-```go
-func (r PreferDoubleBrackets) Name() string
-```
-
-
-
-
-##### type Profile
-
-Profile identifies one complete, versioned configured rule set. Profile versions are owned by the rule registry and are independent from project configuration schema versions.
-
-```go
-type Profile string
-```
-
-
-
-```go
-const (
-    // ProjectProfileV1 is the first configured Z-Shell project rule profile.
-    ProjectProfileV1 Profile = "z-shell/project@1"
-
-    // CurrentProjectProfile is selected for validated project configurations in
-    // this release.
-    CurrentProjectProfile = ProjectProfileV1
-)
-```
-
-
-##### type ProjectUnloadLifecycle
-
-ProjectUnloadLifecycle checks configured registration and unload presence across every source supplied in one project invocation.
-
-```go
-type ProjectUnloadLifecycle struct{}
-```
-
-
-###### func \(ProjectUnloadLifecycle\) Analyze
-
-```go
-func (ProjectUnloadLifecycle) Analyze(_ *analyzer.Context, _ syntax.Node)
-```
-
-
-
-
-###### func \(ProjectUnloadLifecycle\) AnalyzeProject
-
-```go
-func (rule ProjectUnloadLifecycle) AnalyzeProject(ctx *analyzer.ProjectContext)
-```
-
-
-
-
-###### func \(ProjectUnloadLifecycle\) ID
-
-```go
-func (ProjectUnloadLifecycle) ID() diag.RuleID
-```
-
-
-
-
-###### func \(ProjectUnloadLifecycle\) Name
-
-```go
-func (ProjectUnloadLifecycle) Name() string
-```
-
-
-
-
-##### type RepeatedExternalCommand
-
-RepeatedExternalCommand reports known external commands in completion loops.
-
-ID: `performance/repeated-external-command`
-
-Name: Repeated external command in completion loop
-
-Summary: Reports a conservative allowlist of commands that necessarily create a process when they occur in a loop in a configured completion source.
-
-Why: A loop with N iterations creates N external processes for each reported call. Process creation is the dominant fixed cost even when the command does little work. Hoist invariant work, use Zsh\-native parameter operations, or measure and retain the call when its result genuinely varies per iteration.
-
-Severity: Info. The cost model is certain, but whether it matters depends on iteration count, command work, and the interactive completion workload.
-
-False positives: A command whose result must be recomputed for each item may be intentional. Measure the completion path before changing behavior.
-
-```go
-type RepeatedExternalCommand struct{}
-```
-
-
-###### func \(RepeatedExternalCommand\) Analyze
-
-```go
-func (rule RepeatedExternalCommand) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(RepeatedExternalCommand\) ID
-
-```go
-func (RepeatedExternalCommand) ID() diag.RuleID
-```
-
-
-
-
-###### func \(RepeatedExternalCommand\) Name
-
-```go
-func (RepeatedExternalCommand) Name() string
-```
-
-
-
-
-##### type SpecialParamShadow
-
-SpecialParamShadow reports declarations that shadow parameters set by the shell.
-
-ID: `compat/special-param-shadow`
-
-Name: Shadowing special shell parameters
-
-Summary: Reports `local`, `typeset`, `declare`, or `readonly` declarations of a curated set of shell\-set parameters \(for example `ZSH_VERSION`, `OSTYPE`, and `pipestatus`\); explicit non\-local `-g` declarations \(including `readonly -g`\), the `export` builtin, and `typeset`\-family query/display/function modes \(standalone `+`, `-p`/`+p`, `+m`, and `-f`/`+f`\) are excluded. Pattern declarations with `-m` are reported only when an effective `+g` makes matching non\-local parameters local. The rule also stays silent when dynamic option words or the ambient `GLOBAL_EXPORT` option make declaration scope uncertain. Reads are never reported.
-
-Why: The Zsh manual's zshparam "Parameters Set By The Shell" section documents these as shell\-provided state. In a function, `readonly` is `typeset -r` and creates a local binding unless `-g` explicitly selects non\-local behavior. Version probes such as `is-at-least $ZSH_VERSION` are pervasive in plugin code, so a `local ZSH_VERSION=...` in a caller silently feeds the override to all nested code for the lifetime of the scope. At top level, the same declaration form clobbers the shell\-managed outer binding instead of creating a temporary local. Unlike ordinary shadowing, the reader has no declaration of the original to look up \-\- the shell set it. See https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Set-By-The-Shell.
-
-Bad:
-
-```zsh
-compile_zsh() {
-  local ZSH_VERSION="$1"
-}
-```
-
-Good:
-
-```zsh
-compile_zsh() {
-  local target_zsh_version="$1"
-}
-```
-
-Severity: Warning. The pattern is functional but misleading and can change what nested code observes; deliberate compatibility shims are realistic, so it is suppressible rather than an error.
-
-False positives: Deliberate compatibility shims or test harnesses that fake `ZSH_VERSION` or `OSTYPE` for downstream code are the rule's target behavior made intentional; suppress them with a reason. The rule flags only a curated allowlist of read\-mostly shell\-set parameters and stays silent for reads and the conventionally mutated `path`, `fpath`, `PATH`, `REPLY`, and `match`. The shell\-special `status` and `pipestatus` cases remain included because `local -h status=...` and `local -h pipestatus=(...)` can replace their special behavior with ordinary local bindings.
-
-Suppression: Use `# zsh-lint disable=compat/special-param-shadow -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: Issue \#64 records `zd/docker/utils.zsh:78`: `local ZSH_VERSION="$1"` inside a helper that takes a target version as its first argument. Deferred issue \#72 tracks bare assignments in function scope and `integer`/`float` declarations; both are out of scope for this rule version.
-
-```go
-type SpecialParamShadow struct{}
-```
-
-
-###### func \(SpecialParamShadow\) Analyze
-
-```go
-func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(SpecialParamShadow\) ID
-
-```go
-func (SpecialParamShadow) ID() diag.RuleID
-```
-
-
-
-
-###### func \(SpecialParamShadow\) Name
-
-```go
-func (SpecialParamShadow) Name() string
-```
-
-
-
-
-##### type UnloadFunction
-
-UnloadFunction checks plugin entrypoints for lifecycle unload conventions.
-
-ID: `plugin/unload-function`
-
-Name: Unload function convention and hygiene
-
-Summary: Checks configured plugin and Zi annex sourced\-library entrypoints that register persistent shell hooks or widgets for a namespaced unload function \(`*_plugin_unload`\), and checks that defined unload functions cleanly unfunction themselves upon completion. Configured multi\-file invocations aggregate registration and unload presence across the project; unconfigured analysis retains the legacy per\-file path heuristic.
-
-Why: The Zsh Plugin Standard specifies that plugins with persistent side effects \(hooks via `add-zsh-hook`, line\-editor widgets via `add-zle-hook-widget` or `zle -N`\) should provide a namespaced `*_plugin_unload` function so plugin managers and users can cleanly unload the plugin without restarting the shell. The unload function must explicitly remove only its own resources and unfunction itself upon completion. See https://wiki.zshell.dev/community/zsh_plugin_standard#lifecycle-and-resource-ownership.
-
-Bad:
-
-```zsh
-#### Plugin installs hook but provides no unload function
-add-zsh-hook precmd _my_precmd
-```
-
-Good:
-
-```zsh
-add-zsh-hook precmd _my_precmd
-
-my_plugin_unload() {
-  emulate -L zsh
-  autoload -Uz add-zsh-hook
-  add-zsh-hook -d precmd _my_precmd
-  unfunction _my_precmd my_plugin_unload
-}
-```
-
-Severity: Hint. Missing unload functions or self\-unfunction in unload definitions are lifecycle recommendations. Indiscriminate function wiping is a Warning.
-
-False positives: Plugins intended only for static, once\-per\-session loading without unload support. Suppress with a reason.
-
-Suppression: Use `# zsh-lint disable=plugin/unload-function -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: `zsh-fancy-completions/lib/state.zsh:72` implements `zsh-fancy-completions_plugin_unload` with full resource restoration and self\-unfunction.
-
-```go
-type UnloadFunction struct{}
-```
-
-
-###### func \(UnloadFunction\) Analyze
-
-```go
-func (rule UnloadFunction) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(UnloadFunction\) ID
-
-```go
-func (UnloadFunction) ID() diag.RuleID
-```
-
-
-
-
-###### func \(UnloadFunction\) Name
-
-```go
-func (UnloadFunction) Name() string
-```
-
-
-
-
-##### type UnquotedVar
-
-UnquotedVar reports direct, unquoted parameter expansions in command words.
-
-ID: `quoting/unquoted-var`
-
-Name: Unquoted variable expansion
-
-Summary: Reports parameter expansions in command names or arguments that are not enclosed in double quotes.
-
-Why: The Zsh manual's Parameter Expansion section explains that unquoted parameters are not split on whitespace by default, unlike in sh, but null words are still elided; enabling `SH_WORD_SPLIT` also makes unquoted values subject to field splitting. Double quotes preserve an empty scalar as an argument and keep the expansion single\-word under either option state. See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion.
-
-Bad:
-
-```zsh
-print -r -- $value
-```
-
-Good:
-
-```zsh
-print -r -- "$value"
-```
-
-Severity: Warning. Losing an empty argument or inheriting `SH_WORD_SPLIT` can change command behavior, while intentional elision remains realistic.
-
-False positives: Explicit native\-Zsh splitting forms such as `${=words}` and flag\-guided array or field splitting are excluded. Other code may intentionally omit an empty argument, rely on `SH_WORD_SPLIT`, or expand a value guaranteed to be non\-empty. Those cases should use a reasoned suppression rather than weakening unrelated diagnostics.
-
-Suppression: Use `# zsh-lint disable=quoting/unquoted-var -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: Sourced scripts and plugin entrypoints frequently use quoted parameters for scalar configuration and path derivation.
-
-```go
-type UnquotedVar struct{}
-```
-
-
-###### func \(UnquotedVar\) Analyze
-
-```go
-func (r UnquotedVar) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(UnquotedVar\) ID
-
-```go
-func (r UnquotedVar) ID() diag.RuleID
-```
-
-
-
-
-###### func \(UnquotedVar\) Name
-
-```go
-func (r UnquotedVar) Name() string
-```
-
-
-
-
-##### type ZeroHandling
-
-ZeroHandling reports uninitialized top\-level usage of `$0` in plugin entrypoints.
-
-ID: `plugin/zero-handling`
-
-Name: Zero\-handling idiom in plugin entrypoint
-
-Summary: Reports direct uses of `$0` at the top level of configured plugin and Zi annex sourced\-library entrypoints. Configured analysis also reports assignment to special parameter `0`, because sourced entrypoints must not replace caller state. Unconfigured analysis retains the legacy path heuristic.
-
-Why: When a Zsh plugin is sourced, positional parameter `$0` evaluates to the name of the shell \(`zsh` or `-zsh`\) rather than the path of the sourced script, unless `FUNCTION_ARGZERO` is active. Configured plugin entrypoints must resolve the source path with prompt expansion `${(%):-%N}` or `${(%):-%x}` \(optionally with `$ZERO` fallback\) and pass it into a localized scope instead of assigning to caller\-visible special parameter `0`. See https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling.
-
-Bad:
-
-```zsh
-fpath+=( "${0:h}/functions" )
-```
-
-Good \(configured sourced entrypoint\):
-
-```zsh
-() {
-  local source_path=$1
-  fpath+=( "${source_path:h}/functions" )
-} "${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
-```
-
-Severity: Warning. Deriving paths from uninitialized `$0` can load the wrong path; assigning to `0` can replace caller state or fail when `POSIX_ARGZERO` makes it read\-only.
-
-False positives: Scripts intended solely for direct execution \(not sourcing\) or functions where `$0` refers to the function name. Suppress with a reason.
-
-Suppression: Use `# zsh-lint disable=plugin/zero-handling -- <reason>` on the finding line or immediately before the next non\-comment, non\-blank source line.
-
-Corpus evidence: z\-a\-meta\-plugins, zsh\-fancy\-completions, and zsh\-eza use the caller\-preserving anonymous\-function argument pattern.
-
-```go
-type ZeroHandling struct{}
-```
-
-
-###### func \(ZeroHandling\) Analyze
-
-```go
-func (rule ZeroHandling) Analyze(ctx *analyzer.Context, node syntax.Node)
-```
-
-
-
-
-###### func \(ZeroHandling\) ID
-
-```go
-func (ZeroHandling) ID() diag.RuleID
-```
-
-
-
-
-###### func \(ZeroHandling\) Name
-
-```go
-func (ZeroHandling) Name() string
-```
-
-
-
-Generated by [gomarkdoc](https://github.com/princjef/gomarkdoc)
-
-{/* zsh-lint:generated:end */}
-
-{/* end-of-file */}
-{/* links */}
-{/* external */}
-
-[z-shell/zsh-lint]: https://github.com/z-shell/zsh-lint
+zsh-lint path/to/script.zsh
+```
+
+If Go's binary directory is not already on your `PATH`, run the installed
+binary as `"$(go env GOPATH)/bin/zsh-lint"`.
+
+:::important File recognition
+The published CLI does not inspect a shebang, require a `.zsh` extension, scan
+directories, or discover files. Every explicit path is treated as Zsh source.
+An extensionless autoloaded function works when you name it directly, while a
+Bash file is still parsed as Zsh if you pass its path.
+:::
+
+## Choose a guide
+
+<CardGrid>
+
+<Card
+  title="Getting started"
+  to="/community/zsh_lint/zsh-lint-getting-started"
+  icon="/img/svg/cards/packages.svg"
+  cta="Run the first check"
+>
+  Install a pinned release, lint a small script, and understand the result.
+</Card>
+
+<Card
+  title="Choosing files"
+  to="/community/zsh_lint/zsh-lint-choosing-files"
+  icon="/img/svg/cards/history-search.svg"
+  cta="Select inputs"
+>
+  Learn how explicit paths, shebangs, extensions, directories, and mixed shell repositories behave.
+</Card>
+
+<Card
+  title="Project configuration"
+  to="/community/zsh_lint/zsh-lint-project-configuration"
+  icon="/img/svg/cards/annexes.svg"
+  cta="Preview main"
+>
+  Try the unreleased configuration support for plugins and multi-profile projects.
+</Card>
+
+<Card
+  title="Rules and suppressions"
+  to="/community/zsh_lint/zsh-lint-rules-and-suppressions"
+  icon="/img/svg/cards/flexible.svg"
+  cta="Handle findings"
+>
+  Read diagnostics and document intentional exceptions without hiding other rules.
+</Card>
+
+<Card
+  title="CI and JSON"
+  to="/community/zsh_lint/zsh-lint-ci-and-json"
+  icon="/img/svg/cards/ecosystem.svg"
+  cta="Automate checks"
+>
+  Add a reproducible GitHub Actions check and consume structured output.
+</Card>
+
+<Card
+  title="Troubleshooting"
+  to="/community/zsh_lint/zsh-lint-troubleshooting"
+  icon="/img/svg/cards/zi-console.svg"
+  cta="Fix common problems"
+>
+  Resolve install, input, parser, exit-code, and configuration surprises.
+</Card>
+
+<Card
+  title="Parser survey"
+  to="/community/zsh_lint/zsh-lint-parser-survey"
+  icon="/img/svg/cards/speed.svg"
+  cta="Survey a corpus"
+>
+  Use the advanced parser-coverage command without running lint rules.
+</Card>
+
+<Card
+  title="Published rule reference"
+  to="/community/zsh_lint/zsh-lint-rule-reference"
+  icon="/img/svg/cards/syntax-highlighting.svg"
+  cta="Browse rules"
+>
+  See the readable rule set generated from the latest published release.
+</Card>
+
+</CardGrid>
+
+## Published and unreleased behavior
+
+The stable guides describe v1.1.0. The project-configuration guide is clearly
+marked as an unreleased preview of `main`. Automatic file discovery and
+shebang-based classification are not implemented; that design is tracked in
+[zsh-lint issue 183](https://github.com/z-shell/zsh-lint/issues/183).
+
+Source code and development status live in
+[z-shell/zsh-lint](https://github.com/z-shell/zsh-lint).

--- a/community/04_zsh_lint/index.mdx
+++ b/community/04_zsh_lint/index.mdx
@@ -40,6 +40,9 @@ An extensionless autoloaded function works when you name it directly, while a
 Bash file is still parsed as Zsh if you pass its path.
 :::
 
+For parser-only corpus evaluation without lint rules, use the advanced
+[`zsh-lint-survey`](./07_parser_survey.mdx) command.
+
 ## Choose a guide
 
 <CardGrid>


### PR DESCRIPTION
Closes #888.

## Summary

- replace the single generated API-heavy page with a beginner-oriented guide set;
- explain installation, explicit file selection, shebang behavior, suppressions, CI, JSON, and troubleshooting;
- separate the published v1.1.0 experience from the unreleased `--config` preview;
- add a readable rule reference generated from published v1.1.0.

## Verification

- production Docusaurus English build
- Prettier 3.8.3
- frontmatter validation
- code-fence and Prism-language tests
- external-link validation
- `git diff --check`

This PR should merge before z-shell/zsh-lint#182, whose updated sync workflow targets the new rule-reference page.
