### PR TITLE
docs(standard): define clean portable contract v2

### DIFF
--- a/community/00_contributing/03_zsh_plugin_standard.mdx
+++ b/community/00_contributing/03_zsh_plugin_standard.mdx
@@ -5,6 +5,7 @@ sidebar_position: 3
 slug: /zsh_plugin_standard
 image: /img/png/theme/z/320x320.png
 description: Standards and best practices for creating Zsh plugins.
+standard_version: 2
 toc_max_heading_level: 3
 keywords:
   - zsh
@@ -16,9 +17,10 @@ keywords:
   - zsh-plugin-standard
 ---
 
-This page defines what a Zsh plugin is and how plugins and plugin managers
-interoperate. Following the portable core lets people source your plugin
-directly or load it through different frameworks and plugin managers.
+This page defines what a Zsh plugin is, how it is structured, and how plugins
+and plugin managers interoperate. Following the portable core lets people
+source your plugin directly or load it through different frameworks and plugin
+managers without learning a repository-specific architecture first.
 
 :::note[Status of this document]
 
@@ -43,16 +45,25 @@ Zsh documentation remains authoritative for shell semantics.
 
 ## Conformance language {/* #conformance-language */}
 
-The terms in this page have these meanings:
+This page publishes version 2 of the portable contract. The terms in this page
+have these meanings:
 
 - **Zsh guarantee** describes behavior documented by the current Zsh manual.
-- **Portable core** describes manager-independent recommendations for a plugin.
-  The nine numbered requirements below are the portable core.
+- **MUST**, **MUST NOT**, **SHOULD**, and **MAY** have their usual normative
+  meanings. A documented reason is required when a plugin does not follow a
+  **SHOULD** rule.
+- **Portable core** describes manager-independent requirements for a plugin.
+  It includes the numbered interoperability requirements and the architecture,
+  loading, namespace, configuration, lifecycle, and testing contracts below.
 - **Optional profile** describes conventions implemented by named managers.
   A plugin can use a profile, but must not silently require it.
 
 A portable plugin does not require a manager, a manager-owned global parameter,
 or a manifest. There is no plugin manifest standard defined by this page.
+
+Version 2 is a clean contract, not a compatibility mode. Older conventions can
+be documented as history, but they are not alternative ways to claim current
+portable conformance.
 
 Each numbered requirement carries a **STATUS** block recording which managers
 implement it, with pinned source citations.
@@ -79,8 +90,9 @@ At a simple level, a plugin:
 
 3. From a broader perspective, a plugin consists of:
 
-   3.1. a directory containing various files: the main script, autoload
-   functions, completions, Makefiles, backend programs, documentation;
+   3.1. a directory containing various files: the main script, private sourced
+   libraries, autoload functions, completions, Makefiles, backend programs, and
+   documentation;
 
    3.2. a sourceable script that obtains the path to its own directory through
    `$0`, as described in [requirement 1](#zero-handling);
@@ -679,6 +691,8 @@ A maintainable layout is:
 ```text title="Example plugin layout"
 example/
 ├── example.plugin.zsh       # authoritative entrypoint
+├── lib/                     # optional private, eagerly sourced helpers
+│   └── setup.zsh
 ├── functions/               # optional autoload functions
 │   └── example_command
 ├── completions/             # optional completion functions
@@ -687,6 +701,22 @@ example/
 ├── LICENSE
 └── README.md
 ```
+
+The directory names describe execution, not merely organization:
+
+- `lib/` contains private implementation files that the entrypoint must source
+  eagerly. Do not add it to `fpath`, and do not retain setup-only functions
+  after loading.
+- `functions/` contains functions loaded through Zsh autoload, normally one
+  function per file. Use it for work not needed during every shell startup.
+- `completions/` contains native `_command` completion functions and follows
+  completion-system ownership rules.
+- `bin/` contains programs the user invokes explicitly. Plugin loading must not
+  execute them as initialization.
+
+Omit a directory when the plugin does not need that execution profile. A
+different directory name must have equally explicit documented semantics; it
+must not blur eager sourcing and autoloading.
 
 Document which directories a direct-source installation should add to `fpath`
 or `PATH`, and see requirements [2](#functions-directory) and
@@ -800,12 +830,14 @@ for the specific option set, and the
 
 ## Names and persistent state {/* #names-and-persistent-state */}
 
-Prefix every persistent function, parameter, widget, style context, and other
-shell-visible name with a stable project identifier:
+Choose one stable, portable ASCII project identifier and document it in the
+README. Prefix every persistent function, parameter, widget, style context,
+hook callback, and other shell-visible name with that identifier. Public names
+use `example_...`; private callbacks and state use `_example_...`:
 
 ```zsh title="Use a project namespace"
-typeset -gA EXAMPLE_STATE
-EXAMPLE_STATE[enabled]=1
+typeset -gA _example_state
+_example_state[enabled]=1
 
 example_refresh() {
   emulate -L zsh
@@ -818,10 +850,54 @@ _example_precmd() {
 }
 ```
 
-The established ecosystem conventions for naming and for shared state are
-documented in [Standard parameter naming](#standard-parameter-naming),
-[Standard `Plugins` hash](#standard-plugins-hash), and
-[Standard function name-space prefixes](#standard-function-name-space-prefixes).
+Prefix matching must respect a name boundary. An identifier of `example` owns
+`example_refresh` and `_example_precmd`; it does not own `exampled` merely
+because the bytes begin the same way.
+
+Maintain a documented public shell surface. It lists every public function,
+parameter, widget, style context, hook, alias, path entry, and unload function.
+Everything else must be private, temporary, or local. Loading must not retain
+setup-only functions, and a plugin must not create generic helper names that
+unrelated plugins could reasonably choose.
+
+Zsh has no plugin-local namespace for persistent callbacks, so a small number
+of project-prefixed globals can be necessary. Minimize and explicitly allowlist
+them rather than encoding arrays into one scalar or retaining every helper from
+an eagerly sourced library.
+
+See [Standard parameter naming](#standard-parameter-naming),
+[Shared `Plugins` hash](#standard-plugins-hash),
+[Standard function name-space prefixes](#standard-function-name-space-prefixes),
+and [Preventing parameter pollution](#preventing-parameter-pollution).
+
+## Configuration contract {/* #configuration-contract */}
+
+Public configuration must use one coherent project-owned interface. For
+ordinary declarative Zsh configuration, use a namespaced `zstyle` context:
+
+```zsh title="Configure a plugin through one style context"
+zstyle ':example:config' mode compact
+zstyle ':example:config' features history matching
+```
+
+Read scalar values with `zstyle -s`, arrays with `zstyle -a`, booleans with
+`zstyle -t`, and document defaults and value types. Contexts must begin with
+the project identifier, and a plugin must not reuse another subsystem's style
+context.
+
+Use a project-owned global parameter only when persistent runtime state needs
+a Zsh type or mutation model that styles cannot provide. Such parameters are
+private implementation state, not a second public configuration interface.
+Keep real indexed and associative arrays when their shape matters.
+
+A conforming plugin must not expose a scatter of independent global parameters
+for ordinary settings. It also must not use exported environment variables as
+a substitute for namespacing. Environment variables are appropriate only when
+a value must cross an `exec` boundary or be inherited by a child process.
+
+Runtime commands may provide a public mutation interface when validation,
+atomic updates, or immediate reconfiguration is required. They must write the
+same documented configuration model rather than introduce a parallel one.
 
 ## Completions and `compinit` ownership {/* #completions-and-compinit-ownership */}
 
@@ -856,12 +932,30 @@ Treat every persistent side effect as an owned resource:
 - temporary files, cache files, and lock files;
 - background workers, coprocesses, and timers;
 - file descriptors and signal traps;
+- modules loaded by the plugin and special parameters created by those modules;
 - entries intentionally added to `path`, `fpath`, or other global arrays.
 
 Provide a namespaced cleanup function as described in
 [requirement 4](#unload-function). It must stop only known worker process IDs,
 wait for them when appropriate, close only stored file descriptors, remove only
 named hooks and functions, and tolerate partial initialization.
+
+Capture prior state before the first mutation. During unload, restore a prior
+value only when the current value is still the value the plugin installed. If
+the user or another component changed it after load, preserve the newer value.
+Remove a project-created container only when it is still project-owned and
+empty; never delete state another component subsequently adopted.
+
+An unload contract is exact, not best effort. Test it in a clean `zsh -f`
+process by taking a baseline before load, recording the declared load surface,
+unloading, and comparing the final shell to the baseline. The observation
+harness must initialize any modules or special parameters it needs before the
+baseline so it does not attribute its own effects to the plugin.
+
+At minimum, compare functions, parameters and attributes, aliases, options,
+traps, loaded modules, hooks, widgets, key bindings, styles, `path`, and
+`fpath`. Also test repeated source, partial initialization failure, hostile
+caller options, non-interactive loading, and user changes made after load.
 
 Update and migration work should be explicit commands or manager hooks, not
 ordinary load-time behavior.
@@ -895,9 +989,15 @@ Use the XDG base-directory variables when the platform and user configuration
 provide them:
 
 ```zsh title="Derive project-owned storage paths"
-typeset -g EXAMPLE_CACHE_DIR=${XDG_CACHE_HOME:-$HOME/.cache}/example
-typeset -g EXAMPLE_STATE_DIR=${XDG_STATE_HOME:-$HOME/.local/state}/example
-typeset -g EXAMPLE_DATA_DIR=${XDG_DATA_HOME:-$HOME/.local/share}/example
+example_prepare_storage() {
+  emulate -L zsh
+
+  local cache_dir=${XDG_CACHE_HOME:-$HOME/.cache}/example
+  local state_dir=${XDG_STATE_HOME:-$HOME/.local/state}/example
+  local data_dir=${XDG_DATA_HOME:-$HOME/.local/share}/example
+
+  # Create only the directory needed by the explicit operation.
+}
 ```
 
 Use cache for reproducible data, state for persistent operational state, and
@@ -1003,7 +1103,7 @@ example_plugin_unload() {
   autoload -Uz add-zsh-hook
   add-zsh-hook -d precmd _example_precmd
   unfunction _example_precmd example_plugin_unload
-  unset EXAMPLE_STATE
+  unset _example_state
 }
 ```
 
@@ -1064,67 +1164,31 @@ shell or outside an active widget.
 
 ### Standard parameter naming {/* #standard-parameter-naming */}
 
-There is a convention already present in the Zsh world: name array variables in
-lowercase and scalars in uppercase. It is followed by the Zsh manual and by the
-shell itself, for example the `REPLY` scalar and the `reply` array.
+Use descriptive lowercase names for local parameters and explicit `typeset`,
+`local`, or `integer` declarations for their types. Use the stable project
+identifier for persistent parameters, with a leading underscore for private
+state, such as `_example_state` and `_example_items`.
 
-The requirement for scalars to be uppercase is best kept only for global
-parameters. It is fine to name local parameters inside a function in lowercase
-even when they are scalars.
+Capitalization is not a type system in Zsh. The shell's `REPLY` and `reply`
+conventions remain relevant when implementing APIs that specify those names,
+but a plugin must not rely on capitalization alone to communicate a parameter's
+type or ownership. Declare the type and namespace explicitly.
 
-An extension to the convention is proposed: name associative arrays, that is
-hashes, capitalized, with only the first letter uppercase and the remaining
-letters lowercase. See the [next section](#standard-plugins-hash) for an
-example. Where a name consists of multiple words, capitalize each of them, as
-in `typeset -A MyHash`.
+Native completion functions retain the required `_command` file and function
+naming convention.
 
-This convention increases code readability and brings order to it.
+### Shared `Plugins` hash {/* #standard-plugins-hash */}
 
-:::note[Direction of travel]
+Older z-shell plugins used a shared hash named `Plugins` as a registry for
+plugin paths and state. It has no ownership boundary: one plugin can create the
+parameter, another can add keys, and neither can determine safely whether the
+container should disappear during unload.
 
-Zsh does not attach meaning to capitalization, so this convention is a
-readability aid rather than a language rule. It remains the established
-ecosystem convention and is documented here because published plugins follow
-it. For **new** plugins, prefer descriptive local names and project-prefixed
-globals as described in
-[Names and persistent state](#names-and-persistent-state), and document every
-global a user may configure. Completion functions retain Zsh's established
-`_command` naming, which the completion system requires.
-
-:::
-
-### Standard `Plugins` hash {/* #standard-plugins-hash */}
-
-A plugin often has to declare global parameters that live throughout a Zsh
-session. Following
-[namespace pollution prevention](#preventing-parameter-pollution), the plugin
-can use a hash to store its values. Additionally, plugins can use a single
-shared hash parameter, called `Plugins`, to limit pollution further.
-
-An example value needed by the plugin:
-
-```zsh showLineNumbers title="Record the plugin directory in the shared hash"
-typeset -gA Plugins
-Plugins[MY_PLUGIN_REPO_DIR]="${0:h}"
-```
-
-This way the data of all plugins is kept in a single parameter, available for
-easy examination and overview, for example through `varied Plugins`, without
-polluting the namespace.
-
-:::note[Direction of travel]
-
-This is the established convention and is used widely across the z-shell
-ecosystem, including Zi itself, so it is documented here as the behavior your
-code and its comments refer to.
-
-Because `Plugins` is shared, keys must be globally unique; prefix every key
-with your project identifier as shown above. For **new** plugins, a
-project-owned hash such as `EXAMPLE_STATE` avoids cross-plugin key collisions
-entirely and is the recommended direction. Both remain valid; do not migrate
-working code solely for this.
-
-:::
+A version 2 portable plugin must not create, require, or write this shared
+hash. A plugin manager may maintain its own registry as an optional manager
+profile, but portable plugin code must work without observing or mutating it.
+Use the [configuration contract](#configuration-contract) for public settings
+and project-prefixed typed parameters only for necessary private runtime state.
 
 ### Standard recommended [options][zsh-options] {/* #standard-recommended-optionszsh-options */}
 
@@ -1206,108 +1270,32 @@ natural to localize them in the main function.
 
 ### Standard function name-space prefixes {/* #standard-function-name-space-prefixes */}
 
-The recommendation in this section originates as the subjective opinion of the
-original author. It can evolve; raise remarks in the
-[wiki issue tracker](https://github.com/z-shell/wiki/issues/new). Older copies
-of this page linked `z-shell/zw`, which now redirects to the same tracker.
+Use portable ASCII names derived from the stable project identifier:
 
-#### The problems solved by the proposition {/* #the-problems-solved-by-the-proposition */}
+- `example_action` for a documented public function;
+- `_example_callback` for a private hook, widget, or style callback;
+- `_example_helper` for a private persistent helper when autoloading or later
+  callbacks genuinely require it;
+- `_command` only for the native completion function for `command`.
 
-When adopted, the proposition addresses the following issues:
+Public and private names are part of the same shell command namespace, so the
+underscore marks visibility but does not replace the project identifier. An
+unprefixed `_callback` is not project-owned.
 
-1. Using the underscore `_` to namespace functions is not ideal, because that
-   prefix is already used by completion functions, so the namespace is heavily
-   populated and plugin functions get lost in it.
+Do not assign semantic roles through punctuation-only or non-ASCII prefixes.
+Names beginning with `.`, `+`, `/`, or similar role markers are harder to
+autoload, type, search, and represent consistently as file names. Manager API
+names beginning with `@`, such as the optional callbacks in requirements
+[5](#run-on-unload-call) and [6](#run-on-update-call), are manager-owned names,
+not a pattern for plugin-defined functions.
 
-2. Not using a prefix at all pollutes the command namespace.
+#### Historical function-name prefixes {/* #the-proposed-function-name-prefixes */}
 
-3. It allows quickly discriminating between function types. Seeing the `→`
-   prefix tells the reader it is a hook-type function, while `@` tells them it
-   is an API-like function.
-
-4. It improves the editing experience by letting the author narrow completion
-   candidates. In Vim, typing <kbd>+</kbd> then <kbd>Ctrl-P</kbd> completes
-   only the output functions. The editor has to be configured to accept these
-   characters as part of keywords; for Vim that is
-   `:set isk+=@-@,.,+,/,:`.
-
-#### The Proposed function-name prefixes {/* #the-proposed-function-name-prefixes */}
-
-The proposed standard prefixes are:
-
-1. `.` for regular private functions. Example: `.prompt_zinc_get_value`.
-
-2. `→` for hook-like functions, so it is used for
-   [Zsh hooks](#use-of-add-zsh-hook-to-install-hooks) and
-   [Zle hooks](#use-of-add-zle-hook-widget-to-install-zle-hooks), and for any
-   other custom hook-like mechanism in the plugin. Example:
-   `→prompt_zinc_precmd`.
-
-   2.1. An earlier version of this document recommended a colon (`:`) prefix.
-   That was problematic, because Windows does not allow colons in file names,
-   so such a function could not be named as an autoload file.
-
-   2.2. The arrow has a rationale behind it: it denotes execution **coming
-   back** to the function at a later time, after it has been registered as a
-   callback or handler.
-
-   2.3. The arrow is typeable on most keyboard layouts as
-   <kbd>Right-Alt</kbd>+<kbd>I</kbd>, and can always be copied. Handler
-   functions occur rarely in code.
-
-   2.4. Zsh supports any string as a function name, because any string can be a
-   **file** name. If there were an exception among callable names, it would be
-   impossible to run a script called `→abcd`. There are **no** exceptions; a
-   function can even be named as a sequence of null bytes:
-
-   ```zsh showLineNumbers
-   ❯ $'\0'() { print hello }
-   ❯ $'\0'
-   hello
-   ```
-
-3. `+` for output functions, that is functions printing to standard output,
-   standard error, or a log. Example: `+prompt_zinc_output_segment`.
-
-4. `/` for debugging functions, that is functions that output debug messages or
-   gather debug data. Note that the slash makes such functions impossible to
-   autoload through the `autoload` mechanism. Example: `/prompt_zinc_dmsg`.
-
-5. `@` for API-like functions, that is functions on the boundary of a subsystem
-   exposing a well-defined, generally fixed interface. For example, this page
-   [defines](#run-on-update-call) `@zsh-plugin-run-on-update`, which exposes a
-   plugin manager's functionality in a well-defined way.
-
-:::note[Direction of travel]
-
-This scheme is in wide use across the z-shell ecosystem, including Zi's own
-source, which is why it is documented here rather than dropped.
-
-Two costs are worth knowing before adopting it in a **new** plugin: the `/`
-prefix makes a function impossible to autoload, and `→` is non-ASCII, so it is
-harder to type, grep, and use in file names on some systems. For new code,
-portable ASCII names such as `example_action` and `_example_callback` avoid
-both. Existing code using the prefixes is correct and should not be migrated
-solely for this.
-
-:::
-
-#### Example code utilizing the prefixes {/* #example-code-utilizing-the-prefixes */}
-
-```zsh showLineNumbers title="The prefixes in use"
-.zinc_register_hooks() {
-  add-zsh-hook precmd →zinc_precmd
-  /zinc_dmsg "Installed precmd hook with the result: $?"
-  @zsh-plugin-run-on-unload "add-zsh-hook -d precmd →zinc_precmd"
-  +zinc_print "Zinc initialization complete"
-}
-```
-
-The `@zsh-plugin-run-on-unload` line above is the optional manager callback
-from [requirement 5](#run-on-unload-call). The manager evaluates that string,
-so never pass untrusted or externally-derived data into the call, and keep the
-snippet literal as shown. A named unload function remains the primary
-mechanism; see [requirement 4](#unload-function).
+Earlier revisions proposed symbolic prefixes for private, hook, output,
+debugging, and API functions. The anchor remains so historical source comments
+still reach an explanation, but those prefixes are not part of version 2
+portable conformance. Refactored plugins should replace them with the ASCII
+project-owned forms above.
 
 ### Preventing function pollution {/* #preventing-function-pollution */}
 
@@ -1386,25 +1374,27 @@ When writing a plugin one often needs to keep state during the Zsh session. It
 is natural to use global parameters for this. As the number of parameters
 grows, one may want to limit it.
 
-A single global parameter per plugin can be sufficient for flat scalar state:
+A single private project-owned parameter can be sufficient for flat scalar
+runtime state:
 
 ```zsh showLineNumbers title="One project-owned hash for flat state"
-typeset -gA PlgMap
+typeset -gA _example_state
 
-PlgMap[state]=1
-PlgMap[mode]=fast
+_example_state[loaded]=1
+_example_state[mode]=fast
 ```
 
 This replaces a scatter of individual globals with one inspectable parameter.
-Following the [Standard `Plugins` hash](#standard-plugins-hash) section, a
-plugin can go further and use the shared `Plugins` hash.
+It remains private runtime state and must not become a second public
+configuration interface. Use the [configuration contract](#configuration-contract)
+for user settings.
 
 :::warning[Do not use this to encode arrays or nested structures]
 
 Earlier revisions of this page recommended flattening real arrays and hashes
-into delimiter-encoded keys, such as `PlgMap[some_array__1]`, and described the
-technique as unproblematic. Testing does not support that. Three traps apply,
-verified on Zsh 5.9.2:
+into delimiter-encoded keys, such as `_example_state[some_array__1]`, and
+described the technique as unproblematic. Testing does not support that. Three
+traps apply, verified on Zsh 5.9.2:
 
 1. **Sorting silently misorders the result.** The obvious `(o)` sort is
    lexicographic, which is wrong for numeric indices. Numeric `(on)` is
@@ -1427,7 +1417,8 @@ verified on Zsh 5.9.2:
    is no "read the keys back" shortcut.
 
 3. **The delimiter is ambiguous.** Zsh hash keys accept arbitrary content,
-   `__` included, so `PlgMap[user__name]` and `PlgMap[user__name__first]`
+   `__` included, so `_example_state[user__name]` and
+   `_example_state[user__name__first]`
    cannot be decoded to a unique structure.
 
 Additionally, `${#array}`, `${array[-1]}`, and `${array[2,4]}` all work
@@ -1509,6 +1500,8 @@ Before publishing a plugin, confirm that:
   `posix_argzero` is either supported or documented as unsupported;
 - `functions/` and `bin/` use the guarded forms from requirements
   [2](#functions-directory) and [3](#binaries-directory);
+- `lib/`, `functions/`, `completions/`, and `bin/` follow their documented
+  eager, autoload, completion, and executable profiles;
 - a namespaced unload function exists per [requirement 4](#unload-function),
   and every hook, widget, worker, descriptor, and file has explicit cleanup;
 - no untrusted data reaches the eval-based callbacks in requirements
@@ -1516,14 +1509,23 @@ Before publishing a plugin, confirm that:
 - every manager capability is feature-tested, and a manager-independent path
   exists;
 - functions localize options and parameters;
-- persistent names and state are project-owned;
+- the README declares one stable ASCII project identifier and the complete
+  public shell surface;
+- persistent names and state are project-owned and setup-only helpers do not
+  remain after load;
+- public configuration uses one namespaced style context or a justified
+  runtime command, not scattered global parameters;
+- portable code neither requires nor mutates shared manager or plugin registry
+  parameters;
 - completion initialization remains under user, framework, or manager control;
 - non-interactive loading does not touch ZLE;
 - loading performs no network access, untrusted evaluation, package
   installation, or unguarded `PATH` mutation;
 - cache, state, and data use appropriate user directories;
 - startup cost has been measured with `zsh/zprof` and end-to-end timing;
-- supported Zsh versions and hostile option combinations are tested; and
+- supported Zsh versions and hostile option combinations are tested;
+- a clean-process lifecycle test proves the declared load surface and exact
+  ownership-aware restoration after unload; and
 - every optional manager profile has an independent test and source citation.
 
 ## Next Steps {/* #next-steps */}

--- a/community/00_contributing/03_zsh_plugin_standard.mdx
+++ b/community/00_contributing/03_zsh_plugin_standard.mdx
@@ -53,8 +53,10 @@ have these meanings:
   meanings. A documented reason is required when a plugin does not follow a
   **SHOULD** rule.
 - **Portable core** describes manager-independent requirements for a plugin.
-  It includes the numbered interoperability requirements and the architecture,
-  loading, namespace, configuration, lifecycle, and testing contracts below.
+  It is the architecture, loading, namespace, configuration, lifecycle, and
+  testing contract below.
+- **Loader interface** describes an optional facility that a plugin manager may
+  expose. It is not part of portable conformance.
 - **Optional profile** describes conventions implemented by named managers.
   A plugin can use a profile, but must not silently require it.
 
@@ -65,8 +67,8 @@ Version 2 is a clean contract, not a compatibility mode. Older conventions can
 be documented as history, but they are not alternative ways to claim current
 portable conformance.
 
-Each numbered requirement carries a **STATUS** block recording which managers
-implement it, with pinned source citations.
+Each optional loader interface carries a **STATUS** block recording which
+managers implement it, with pinned source citations.
 
 ## What is a Zsh plugin? {/* #what-is-a-zsh-plugin */}
 
@@ -74,40 +76,25 @@ Zsh plugins were first defined in practice by Oh My Zsh. They provide a way to
 package together files that extend or configure the shell's functionality in a
 particular way.
 
-At a simple level, a plugin:
+At a simple level, a plugin is a directory with one documented sourceable Zsh
+entrypoint. It may also contain private sourced libraries, autoload functions,
+completions, user-invoked programs, and documentation. Each directory has the
+execution semantics defined by the portable layout below.
 
-1. Has a directory added to `$fpath`
-   ([Zsh documentation: Autoloading Functions][autoloading-functions]). This is
-   done either by a plugin manager or by the plugin itself; see
-   [requirement 2](#functions-directory) and
-   [requirement 7](#activity-indicator).
+A plugin can be sourced directly without a manager. A framework or manager may
+discover the entrypoint and arrange `fpath`, but the portable plugin must not
+require manager state merely to load or unload.
 
-2. Has its first `*.plugin.zsh` file sourced. The names `*.zsh`, `init.zsh`,
-   and `*.sh` are also seen in the wild, but they are non-standard.
+## Optional loader interfaces {/* #optional-loader-interfaces */}
 
-   2.1. Point 1 allows plugins to provide completions and autoload functions
-   loaded through Zsh's `autoload` mechanism, one function per file.
+The following numbered interfaces document facilities implemented by existing
+plugin managers. They are not portable requirements and a plugin does not need
+to implement or inspect any of them. A plugin that deliberately opts into one
+must feature-test that exact facility, retain its direct-source behavior, and
+test the named manager profile independently.
 
-3. From a broader perspective, a plugin consists of:
-
-   3.1. a directory containing various files: the main script, private sourced
-   libraries, autoload functions, completions, Makefiles, backend programs, and
-   documentation;
-
-   3.2. a sourceable script that obtains the path to its own directory through
-   `$0`, as described in [requirement 1](#zero-handling);
-
-   3.3. a repository on GitHub or another host, identified by two components,
-   **username**/**plugin-name**;
-
-   3.4. a software package containing command line artifacts of any kind, when
-   used with advanced plugin managers that have hooks, can run Makefiles, and
-   can add directories to `$PATH`.
-
-The requirements below codify that definition and the corresponding actions of
-plugin managers.
-
-## Portable core {/* #portable-core */}
+These interfaces are retained as manager interoperability reference, not as a
+legacy conformance mode.
 
 ### 1. Standardized `$0` handling {/* #zero-handling */}
 
@@ -669,6 +656,12 @@ fi
 - **Adoption:** across all 57 plugin and library entrypoints in the z-shell
   organization, `f` is tested 31 times, `b` four times, `P` once, and `X` never.
 
+## Portable core {/* #portable-core */}
+
+The portable core begins here. Conformance does not depend on any interface in
+the preceding optional loader reference. The rules in this section through
+[Tests](#tests) define the manager-independent contract.
+
 ## Entrypoints and repository layout {/* #entrypoints-and-repository-layout */}
 
 Provide one authoritative, sourceable Zsh entrypoint. A file named after the
@@ -685,6 +678,24 @@ Entrypoint discovery is not universal. For example, zcomet has its own ordered
 3. Keep alternate entrypoints, if supplied, as thin wrappers around one
    implementation.
 4. Make repeated loading harmless, or reject it with a clear diagnostic.
+
+Resolve the entrypoint directory from the sourced file, not from the caller's
+working directory. The standard expression accepts an optional manager-supplied
+`ZERO`, preserves ordinary source behavior through `$0`, falls back to `%N`,
+and makes the result absolute without resolving symlinks:
+
+```zsh title="Resolve the authoritative entrypoint"
+local source_path plugin_dir
+source_path="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
+plugin_dir=${source_path:a:h}
+```
+
+Use a local parameter inside a scoped loader. Do not overwrite global `0`.
+This form therefore remains valid when `posix_argzero` makes `0` read-only.
+`%N` is not guaranteed to be absolute, which is why the `:a` modifier is
+required. See [the loader interoperability reference](#zero-handling) for
+manager evaluation details and the official
+[Zsh filename modifiers][zsh-modifiers] for `:a`, `:A`, and `:P`.
 
 A maintainable layout is:
 
@@ -719,8 +730,9 @@ different directory name must have equally explicit documented semantics; it
 must not blur eager sourcing and autoloading.
 
 Document which directories a direct-source installation should add to `fpath`
-or `PATH`, and see requirements [2](#functions-directory) and
-[3](#binaries-directory) for the guarded snippets that do it.
+or `PATH`. A plugin may add its own `functions/` or `completions/` directory to
+`fpath` after checking that the exact path is absent. Do not mutate `PATH`
+during ordinary loading; document `bin/` for the user or manager instead.
 
 ## Loading contract and security {/* #loading-contract-and-security */}
 
@@ -729,8 +741,7 @@ plugin must not:
 
 - access the network, or download or install packages;
 - evaluate untrusted text, or text fetched at load time;
-- mutate `PATH` outside the guarded form in
-  [requirement 3](#binaries-directory);
+- mutate `PATH`;
 - write into its own checkout, which may be read-only or manager-controlled;
 - change global options as an incidental effect;
 - change the working directory without restoring it, or disturb the directory
@@ -747,10 +758,8 @@ work at load time.
 explicit user action, such as a command the user runs, not a side effect of
 starting a shell.
 
-**Do not automatically prepend** or append to `PATH`. The only sanctioned
-`path` extension is the capability-guarded `bin/` form in
-[requirement 3](#binaries-directory), and even that yields to any manager
-advertising the capability. Leave `$ZPFX/bin` to the user or the manager.
+**Do not automatically prepend** or append to `PATH`. Document the plugin's
+`bin/` directory for explicit user or manager configuration.
 
 Treat all user-supplied and externally-derived text as untrusted data, never as
 code.
@@ -772,8 +781,8 @@ A **plugin manager** may load a plugin by evaluating its text, for example with
 interface and it belongs to the manager alone: never pass untrusted or
 externally-derived text through it. A manager that evaluates a plugin must
 supply `ZERO`, because evaluated text has no `%N` path of its own to fall back
-on. That obligation is the reason [requirement 1](#zero-handling) reads `ZERO`
-before `%N`.
+on. This optional hand-off is documented in the
+[loader interoperability reference](#zero-handling).
 
 There is no contradiction between the two: a plugin must never evaluate its own
 or another plugin's text, while a manager evaluating a plugin it loaded is a
@@ -902,9 +911,9 @@ same documented configuration model rather than introduce a parallel one.
 ## Completions and `compinit` ownership {/* #completions-and-compinit-ownership */}
 
 Store each native completion in a file named `_command`. Make the directory
-available on `fpath` before completion initialization, either through explicit
-user configuration or manager configuration; see
-[requirement 2](#functions-directory).
+available on `fpath` before completion initialization, either through the
+plugin's exact-path membership check, explicit user configuration, or manager
+configuration.
 
 The plugin should not run `compinit` during ordinary loading. The shell
 configuration, framework, or manager owns completion initialization and should
@@ -935,8 +944,9 @@ Treat every persistent side effect as an owned resource:
 - modules loaded by the plugin and special parameters created by those modules;
 - entries intentionally added to `path`, `fpath`, or other global arrays.
 
-Provide a namespaced cleanup function as described in
-[requirement 4](#unload-function). It must stop only known worker process IDs,
+Provide a namespaced cleanup function whose name is derived from the documented
+project identifier, for example `example_plugin_unload`. It must stop only
+known worker process IDs,
 wait for them when appropriate, close only stored file descriptors, remove only
 named hooks and functions, and tolerate partial initialization.
 
@@ -1003,8 +1013,8 @@ example_prepare_storage() {
 Use cache for reproducible data, state for persistent operational state, and
 data for durable user data. Create directories lazily with restrictive,
 user-appropriate permissions. Do not write into the plugin checkout during
-loading. `$ZPFX`, described in [requirement 8](#global-parameter-with-prefix),
-is a manager installation prefix and is not a substitute for these.
+loading. A manager installation prefix is not a substitute for these user
+directories.
 
 ## Versions and feature compatibility {/* #versions-and-feature-compatibility */}
 
@@ -1045,9 +1055,9 @@ zsh -f -c 'setopt ksharrays shwordsplit globsubst; source ./example.plugin.zsh'
 zsh -f -c 'setopt nofunctionargzero posixargzero; source ./example.plugin.zsh'
 ```
 
-The last line matters for [requirement 1](#zero-handling): under
-`posix_argzero` the parameter `0` is read-only, so a plugin that assigns to it
-fails there.
+The last line verifies the scoped
+[entrypoint form](#entrypoints-and-repository-layout): under `posix_argzero`
+the parameter `0` is read-only, so a plugin that assigns to it fails there.
 
 Run the suite on every supported Zsh version. Add assertions for exported
 functions and parameters, hook registration, repeated loading, explicit
@@ -1285,9 +1295,9 @@ unprefixed `_callback` is not project-owned.
 Do not assign semantic roles through punctuation-only or non-ASCII prefixes.
 Names beginning with `.`, `+`, `/`, or similar role markers are harder to
 autoload, type, search, and represent consistently as file names. Manager API
-names beginning with `@`, such as the optional callbacks in requirements
-[5](#run-on-unload-call) and [6](#run-on-update-call), are manager-owned names,
-not a pattern for plugin-defined functions.
+names beginning with `@`, such as the optional
+[unload](#run-on-unload-call) and [update](#run-on-update-call) callbacks, are
+manager-owned names, not a pattern for plugin-defined functions.
 
 #### Historical function-name prefixes {/* #the-proposed-function-name-prefixes */}
 
@@ -1431,10 +1441,10 @@ Keep real arrays and real hashes whenever order or shape matters.
 
 ## Optional manager interoperability profiles {/* #optional-manager-interoperability-profiles */}
 
-This appendix records how named managers implement the requirements above. It
-does not add anything to the portable core. Detect each facility before using
-it and retain a direct-source fallback. Exact capability strings and behavior
-are manager implementation details, not Zsh guarantees.
+This appendix records how named managers implement the optional loader
+interfaces above. It does not add anything to the portable core. Detect each
+facility before using it and retain direct-source behavior. Exact capability
+strings and behavior are manager implementation details, not Zsh guarantees.
 
 ### Zi profile: canonical for z-shell {/* #zi-profile */}
 
@@ -1496,18 +1506,14 @@ list as a universal capability registry.
 Before publishing a plugin, confirm that:
 
 - one documented entrypoint works with `source` under `zsh -f`;
-- self-location follows [requirement 1](#zero-handling), and the behavior under
-  `posix_argzero` is either supported or documented as unsupported;
-- `functions/` and `bin/` use the guarded forms from requirements
-  [2](#functions-directory) and [3](#binaries-directory);
+- self-location uses the scoped entrypoint form and remains valid under
+  `posix_argzero`;
 - `lib/`, `functions/`, `completions/`, and `bin/` follow their documented
   eager, autoload, completion, and executable profiles;
-- a namespaced unload function exists per [requirement 4](#unload-function),
+- `functions/` and `completions/` use exact `fpath` membership checks, while
+  ordinary loading does not mutate `PATH`;
+- a project-identifier-derived unload function exists,
   and every hook, widget, worker, descriptor, and file has explicit cleanup;
-- no untrusted data reaches the eval-based callbacks in requirements
-  [5](#run-on-unload-call) and [6](#run-on-update-call);
-- every manager capability is feature-tested, and a manager-independent path
-  exists;
 - functions localize options and parameters;
 - the README declares one stable ASCII project identifier and the complete
   public shell surface;
@@ -1526,7 +1532,8 @@ Before publishing a plugin, confirm that:
 - supported Zsh versions and hostile option combinations are tested;
 - a clean-process lifecycle test proves the declared load surface and exact
   ownership-aware restoration after unload; and
-- every optional manager profile has an independent test and source citation.
+- every deliberately supported optional manager interface is feature-tested,
+  has an independent profile test, and retains direct-source behavior.
 
 ## Next Steps {/* #next-steps */}
 

--- a/scripts/validate-plugin-standard.mjs
+++ b/scripts/validate-plugin-standard.mjs
@@ -29,6 +29,7 @@ const REQUIRED_ANCHORS = [
   "use-of-add-zle-hook-widget-to-install-zle-hooks",
   "standard-parameter-naming",
   "standard-plugins-hash",
+  "configuration-contract",
   "the-proposed-function-name-prefixes",
   "status--zero-handling-",
   "status--functions-directory-",
@@ -43,7 +44,9 @@ const REQUIRED_ANCHORS = [
 
 const REQUIRED_STANDARD_TEXT = [
   "This is ecosystem guidance, not an official Zsh language specification.",
+  "standard_version: 2",
   "## Portable core",
+  "## Configuration contract",
   "## Optional manager interoperability profiles",
   // Managers are named where a plugin author needs the interop fact, which is
   // the profile appendix, not the page introduction. These pins keep the
@@ -65,6 +68,9 @@ const REQUIRED_STANDARD_TEXT = [
   "zsh/zprof",
   "Do not access the network",
   "Do not automatically prepend",
+  "`lib/` contains private implementation files",
+  "must not create, require, or write this shared hash",
+  "clean-process lifecycle test",
   "There is no plugin manifest standard",
 ];
 
@@ -146,6 +152,9 @@ export function validateStandard(content) {
   if (!/^slug: \/zsh_plugin_standard$/m.test(content)) {
     errors.push("frontmatter must preserve slug: /zsh_plugin_standard");
   }
+  if (!/^standard_version: 2$/m.test(content)) {
+    errors.push("frontmatter must publish standard_version: 2");
+  }
 
   errors.push(...missingText(content, REQUIRED_STANDARD_TEXT, "standard"));
   errors.push(
@@ -175,6 +184,8 @@ export function validateStandard(content) {
     ],
     [/PMSPEC=0fuUpiPs(?!X)/, "must not publish the obsolete PMSPEC value as a universal contract"],
     [/zmodload\s+-e\s+zsh\/zle/, "must load zsh/zle before testing the required ZLE facility"],
+    [/^typeset -gA Plugins$/m, "must not publish shared Plugins registry creation as portable code"],
+    [/Both remain valid/i, "must not preserve incompatible legacy alternatives as current conformance"],
   ];
   for (const [pattern, message] of stalePatterns) {
     if (pattern.test(content)) {
@@ -182,15 +193,8 @@ export function validateStandard(content) {
     }
   }
 
-  // Established ecosystem conventions may be documented, because published
-  // plugins link to these anchors and their code comments must land on prose
-  // that explains the code beneath them. They must never be promoted
-  // unqualified: each one carries a note stating the recommended direction for
-  // new plugins, and the eval-based manager callbacks carry a warning against
-  // passing untrusted data. Publishing the convention without its qualifier is
-  // the regression this guards, not the convention itself.
-  errors.push(...requiresQualifier(content, "typeset -gA Plugins", "Direction of travel", "shared Plugins hash"));
-  errors.push(...requiresQualifier(content, "→prompt_zinc_precmd", "Direction of travel", "function-name prefixes"));
+  // Eval-based manager interfaces remain documented for interoperability, but
+  // each occurrence must retain its nearby trust-boundary qualifier.
   errors.push(
     ...requiresQualifier(content, "@zsh-plugin-run-on-unload ", "never pass untrusted", "eval-based unload callback"),
   );

--- a/scripts/validate-plugin-standard.mjs
+++ b/scripts/validate-plugin-standard.mjs
@@ -45,6 +45,7 @@ const REQUIRED_ANCHORS = [
 const REQUIRED_STANDARD_TEXT = [
   "This is ecosystem guidance, not an official Zsh language specification.",
   "standard_version: 2",
+  "## Optional loader interfaces",
   "## Portable core",
   "## Configuration contract",
   "## Optional manager interoperability profiles",
@@ -163,10 +164,25 @@ export function validateStandard(content) {
     ),
   );
 
+  const interfacesIndex = content.indexOf("## Optional loader interfaces");
   const coreIndex = content.indexOf("## Portable core");
   const profilesIndex = content.indexOf("## Optional manager interoperability profiles");
-  if (coreIndex < 0 || profilesIndex < 0 || coreIndex >= profilesIndex) {
-    errors.push("portable core must appear before optional manager profiles");
+  if (
+    interfacesIndex < 0 ||
+    coreIndex < 0 ||
+    profilesIndex < 0 ||
+    interfacesIndex >= coreIndex ||
+    coreIndex >= profilesIndex
+  ) {
+    errors.push("optional loader interfaces, portable core, and manager profiles must appear in that order");
+  } else {
+    const portableCore = content.slice(coreIndex, profilesIndex);
+    const managerOnlyTokens = ["PMSPEC", "zsh_loaded_plugins", "ZPFX", "@zsh-plugin-"];
+    for (const token of managerOnlyTokens) {
+      if (portableCore.includes(token)) {
+        errors.push(`portable core must not depend on optional manager interface: ${token}`);
+      }
+    }
   }
   errors.push(...validateZleExample(content, "Register an interactive ZLE hook", true));
   errors.push(...validateZleExample(content, "Check an optional feature", false));

--- a/scripts/validate-plugin-standard.test.mjs
+++ b/scripts/validate-plugin-standard.test.mjs
@@ -35,9 +35,17 @@ test("accepts the repository standard and review workflow", () => {
   assert.deepEqual(validateRepository({standard, workflow}), []);
 });
 
-test("requires the portable core to precede optional profiles", () => {
+test("requires optional interfaces, portable core, and profiles in order", () => {
   const invalid = standard.replace("## Portable core", "## Removed portable core");
-  assert.match(validateStandard(invalid).join("\n"), /Portable core|portable core/);
+  assert.match(validateStandard(invalid).join("\n"), /portable core/);
+});
+
+test("rejects manager-only interfaces inside the portable core", () => {
+  const invalid = standard.replace(
+    "The portable core begins here.",
+    "The portable core begins here and requires PMSPEC.",
+  );
+  assert.match(validateStandard(invalid).join("\n"), /optional manager interface: PMSPEC/);
 });
 
 test("requires the version 2 clean portable contract", () => {

--- a/scripts/validate-plugin-standard.test.mjs
+++ b/scripts/validate-plugin-standard.test.mjs
@@ -40,6 +40,21 @@ test("requires the portable core to precede optional profiles", () => {
   assert.match(validateStandard(invalid).join("\n"), /Portable core|portable core/);
 });
 
+test("requires the version 2 clean portable contract", () => {
+  const invalid = standard.replace("standard_version: 2", "standard_version: 1");
+  assert.match(validateStandard(invalid).join("\n"), /standard_version: 2/);
+});
+
+test("rejects portable shared Plugins registry creation", () => {
+  const invalid = `${standard}\n\`\`\`zsh\ntypeset -gA Plugins\n\`\`\`\n`;
+  assert.match(validateStandard(invalid).join("\n"), /shared Plugins registry/);
+});
+
+test("rejects legacy alternatives as current conformance", () => {
+  const invalid = `${standard}\nBoth remain valid for conforming plugins.\n`;
+  assert.match(validateStandard(invalid).join("\n"), /legacy alternatives/);
+});
+
 test("requires scoped entrypoint cleanup to preserve loader status", () => {
   const invalid = standard.replace('return "$loader_status"\n} "$@"', 'return 0\n} "$@"');
   assert.match(validateStandard(invalid).join("\n"), /return the loader status/);


### PR DESCRIPTION
## Summary

- publish Zsh Plugin Standard 2 as one clean, portable contract for all plugin authors
- define consistent repository layout, namespace, configuration, public-surface, ownership, unload, and lifecycle-test requirements
- retire the shared `Plugins` registry and symbolic function-prefix schemes from current conformance
- extend the deterministic standard validator and regression tests for the versioned contract

## Why

The existing page mixed portable requirements, historical z-shell conventions, and permissive alternatives. That made structurally different plugins appear equally conforming and left tools without one executable contract. Version 2 makes the portable standard itself the canonical architecture, without a z-shell-only compatibility layer.

## Validation

- `pnpm validate:plugin-standard`
- `pnpm validate:frontmatter`
- `pnpm validate:code-fences`
- `pnpm build:en`
- `trunk check community/00_contributing/03_zsh_plugin_standard.mdx scripts/validate-plugin-standard.mjs scripts/validate-plugin-standard.test.mjs` (commit hook, passed)
- direct gitleaks scan, no leaks found
- `git diff --check`

## Instruction impact

This changes the canonical public plugin-authoring contract. Follow-up pull requests will align organization instructions, patterns, templates, zsh-lint, ZUnit, and the zsh-fancy-completions pilot after this dependency is accepted.

Closes #848
Parent initiative: z-shell/.github#556
