### PR TITLE
docs: serve the organization summary from GitHub Pages

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -57,13 +57,13 @@ Zi is a Swiss Army Knife for Zsh — a blazing-fast plugin manager with Turbo mo
     alt="Z-Shell Metrics"
     width="100%"
     height="auto"
-    img="https://raw.githubusercontent.com/z-shell/.github/metrics/metrics/plugin/metrics.svg"
+    img="https://z-shell.github.io/.github/metrics/plugin/metrics.svg"
   />
   <ImgShow
     alt="Z-Shell Repositories"
     width="100%"
     height="auto"
-    img="https://raw.githubusercontent.com/z-shell/.github/metrics/metrics/plugin/repositories_metrics.svg"
+    img="https://z-shell.github.io/.github/metrics/plugin/repositories_metrics.svg"
   />
 </Link>
 


### PR DESCRIPTION
## Summary

Point the `## Summary` images on the docs landing page at GitHub Pages instead
of `raw.githubusercontent.com`.

Until today these images rendered placeholder data (`NaN members`, `0 Stargazers`)
because of a token defect in the workflow that generates them. That is fixed in
z-shell/.github#578, and the same PR reworked GitHub Pages to publish the metrics
SVGs as a curated asset set rather than serving the whole repository.

`raw.githubusercontent.com` serves with a short cache lifetime and no cache
busting, so the figures shown on the wiki could lag behind the branch content.
The Pages origin is the intended public location for these assets.

## Verification

Both new URLs return 200 and carry current figures:

```
200  https://z-shell.github.io/.github/metrics/plugin/metrics.svg
     -> "Z-Shell ... 4 members ... Verified"
200  https://z-shell.github.io/.github/metrics/plugin/repositories_metrics.svg
     -> "93 Repositories, 48 Releases, 1574 Stargazers, 166 Forkers, 30 Watchers"
```

Text-only change to two `img` attributes; formatting and surrounding markup are
untouched.
