### PR TITLE
docs(annexes): document @zi-unregister-annex

### DIFF
--- a/ecosystem/annexes/0_overview.mdx
+++ b/ecosystem/annexes/0_overview.mdx
@@ -133,6 +133,41 @@ zi load some/plugin
 
 Check out the project which fully implements this idea, [z-a-submods][submods]. It e.g. also implements the `atpull` hook, i.e. supports the automatic update of the submodules. The `z-a-*` prefix is recommended for projects which indicate annexes.
 
+## Unregistering an annex {/* #unregistering-an-annex */}
+
+An annex that follows the [Zsh Plugin Standard][zsh-plugin-standard] unload contract removes its handler functions when it is unloaded. Removing a handler without also removing its registration leaves Zi dispatching to a function that no longer exists, so the registration has to go first:
+
+`@zi-unregister-annex`:
+
+```zi showLineNumbers
+myproject_plugin_unload() {
+  @zi-unregister-annex myproject hook:atclone
+  unfunction →za-myproject-atclone-handler \
+    →za-myproject-atclone-help-handler \
+    myproject_plugin_unload
+}
+```
+
+The general syntax mirrors the registration call, using the same project name and hook type that were given to `@zi-register-annex`:
+
+```zi showLineNumbers
+@zi-unregister-annex {project-name} { hook: < hook-type >| subcommand: < subcommand-name > }
+```
+
+Unregistering something that was never registered is a no-op, not an error, so an unload function does not need to guard the call.
+
+:::warning
+
+Removing a handler without unregistering it corrupts later loads. Zi calls the stored handler unconditionally, a missing function returns `127`, and Zi folds that error into its return value and shifts its argument list. Every plugin loaded afterwards in that session is affected, and the first one fails with `Error: No plugin or snippet ID given.`
+
+:::
+
+:::info
+
+The ice-modifiers an annex contributed at registration are not withdrawn. Registration appends them to a shared list without recording which annex contributed which entry, so a leftover ice name stays recognised but dispatches to nothing.
+
+:::
+
 ## Summary {/* #summary */}
 
 There are 2 or 3 subtypes for each of the hooks:
@@ -148,6 +183,7 @@ There are 2 or 3 subtypes for each of the hooks:
 [command]: /docs/guides/commands
 [ice-modifiers]: /docs/guides/syntax/ice-modifiers
 [the-proposed-function-name-prefixes]: /community/zsh_plugin_standard#the-proposed-function-name-prefixes
+[zsh-plugin-standard]: /community/zsh_plugin_standard#unload-function
 
 {/* external */}
 


### PR DESCRIPTION
Documents `@zi-unregister-annex`, the counterpart to `@zi-register-annex` added in [z-shell/zi#503](https://github.com/z-shell/zi/pull/503). One page, English source only.

## Why

The overview documented registration with no counterpart, so an annex had no documented way to satisfy the Zsh Plugin Standard unload contract.

Removing a handler while its registration survives leaves Zi dispatching to a function that no longer exists. A missing function returns `127`, `127 & 1` is true, so Zi folds the error into its return value **and shifts its argument list**. Later plug-ins stop loading for the rest of the session, and the first one fails with `Error: No plugin or snippet ID given.`

That consequence gets a `:::warning` because the symptom appears a long way from its cause: a plug-in that has nothing to do with the annex simply fails to load.

`z-shell/z-a-meta-plugins` works around the missing API today by leaving an inert stub in place of its handler, and can stop once this is available.

## What is covered

- the signature, mirroring the registration call's project name and hook type
- an example placing the call inside the annex's `*_plugin_unload` function
- that unregistering something never registered is a no-op, so unload functions need no guard
- the one limit, in an `:::info`: ice-modifiers contributed at registration are not withdrawn, because registration does not record which annex contributed which entry, so a leftover ice name stays recognised but dispatches to nothing

## Checks

`node scripts/validate-code-fences.mjs` passes. Both new fences use `zi`, which the validator's `SUPPORTED_LANGUAGES` includes and which the surrounding page already uses.

The new `[zsh-plugin-standard]` link reference resolves to `/community/zsh_plugin_standard#unload-function`; that anchor exists at `community/03_zsh_plugin_standard.mdx:325`.

The heading carries an explicit id in the same `{/* #... */}` form as the rest of the page. Admonitions and code fences balance.

I did not run a full `pnpm build`: this is a docs-only section addition and the worktree has no `node_modules`. The fence validator, which is the check that covers what changed, runs standalone and passes.

Closes #912
